### PR TITLE
Deploys in v4 now require RH registry images

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,16 +1,14 @@
 ############################
 # STEP 1 build executable binary
 ############################
-FROM golang:alpine AS builder
-# Install git.
-# Git is required for fetching the dependencies.
-RUN apk update && apk add --no-cache git
+FROM registry.redhat.io/rhel8/go-toolset:latest AS builder
 WORKDIR $GOPATH/src/mypackage/myapp/
 COPY . .
 # Use go mod
 ENV GO111MODULE=on
 # Fetch dependencies.
-# Using go get.
+# Using go get requires root.
+USER root
 RUN go get -d -v
 # Build the binary.
 RUN CGO_ENABLED=0 go build -o /go/bin/uhc-auth-proxy


### PR DESCRIPTION
golang:alpine is no longer available for this build, but
rhel8/go-toolset:latest seems to include the same tools, though it
requires a privilege escalation during `go get`

Signed-off-by: Chris Mitchell <cmitchel@redhat.com>