### PR TITLE
Added the REPLICA parameter to the UHC-AUTH-PROXY template

### DIFF
--- a/openshift/uhc-auth-proxy-template.yaml
+++ b/openshift/uhc-auth-proxy-template.yaml
@@ -9,6 +9,9 @@ parameters:
   value: staging
 - name: IMAGE_TAG
   value: latest
+- name: REPLICAS
+  description: The number of replicas to use in the deployment
+  value: '1'
 objects:
 - apiVersion: apps/v1
   kind: Deployment
@@ -19,7 +22,7 @@ objects:
   spec:
     minReadySeconds: 15
     progressDeadlineSeconds: 600
-    replicas: 1
+    replicas: ${{REPLICAS}}
     revisionHistoryLimit: 9
     selector:
       matchLabels:


### PR DESCRIPTION
Added the parameter "REPLICAS" to "openshift/uhc-auth-proxy-template.yaml" and defined the variable as " 1 " (Which is was the original value before this modification). 

With the parameter above, we can now more easily define a custom number of pods in a deployment configuration.