### PR TITLE
Fix README capitalization

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ An identification document should look something like this:
 
     {
          "account_number": "123456",
-         "type": "system",
+         "type": "System",
          "internal": {
              "org_id": "1234567"
          }


### PR DESCRIPTION
I'm working on a schema for the identity header, and noticed the README needed
to be updated here to reflect the correct type capitalization of the `type` on the
identity: https://github.com/RedHatInsights/uhc-auth-proxy/blob/3fd2153a61128f0dddf067478ce369f9b7c1c471/requests/cluster/cluster.go#L41