### PR TITLE
Allow acm operator user agent

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,4 +126,20 @@ the root of the project.
 This will build and install the `uhc-auth-proxy` command. You can request an
 identity document like this:
 
-    uhc-auth-proxy --oat $OFFLINE_AUTH_TOKEN --cluster-id $CLUSTER_ID --authorization-token $AUTHORIZATION_TOKEN
+    $ uhc-auth-proxy --oat $OFFLINE_AUTH_TOKEN --cluster-id $CLUSTER_ID --authorization-token $AUTHORIZATION_TOKEN
+
+## Local Development
+
+This will start the service on port `8080`:
+```
+$ uhc-auth-proxy start
+```
+
+Any changes to code will require running `go install` to rebuild.
+
+### Tests
+
+To run tests locally:
+```
+$ go test -v ./...
+```

--- a/server/server.go
+++ b/server/server.go
@@ -47,10 +47,11 @@ const (
 	insightsOperatorPrefix    = `insights-operator/`
 	costMgmtOperatorPrefix    = `cost-mgmt-operator/`
 	marketplaceOperatorPrefix = `marketplace-operator/`
+	acmOperator               = `acm-operator/`
 )
 
 var (
-	operatorPrefixes = [3]string{insightsOperatorPrefix, costMgmtOperatorPrefix, marketplaceOperatorPrefix}
+	operatorPrefixes = [4]string{insightsOperatorPrefix, costMgmtOperatorPrefix, marketplaceOperatorPrefix, acmOperator}
 )
 
 // returns the cluster id from the user agent string used by the support operator

--- a/server/server.go
+++ b/server/server.go
@@ -99,7 +99,7 @@ func RootHandler(wrapper client.Wrapper) func(w http.ResponseWriter, r *http.Req
 
 		var respond = func(code int) {
 			w.WriteHeader(code)
-			responseMetrics.With(prometheus.Labels{"code": string(code)}).Inc()
+			responseMetrics.With(prometheus.Labels{"code": fmt.Sprintf("%d", code)}).Inc()
 		}
 
 		clusterID, err := getClusterID(r.Header.Get("user-agent"))

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -5,6 +5,7 @@ import (
 	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
+	"fmt"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
@@ -121,12 +122,15 @@ var _ = Describe("Handler", func() {
 	})
 
 	Describe("When called with a valid request", func() {
-		It("should return a valid Identity json", func() {
-			_, ident := call(wrapper, "insights-operator/abc cluster/123", "Bearer mytoken")
-			Expect(ident.AccountNumber).To(Equal("123"))
-			Expect(ident.Internal.OrgID).To(Equal("123"))
-			Expect(ident.Type).To(Equal("System"))
-		})
+		validOperatorAgents := []string{"insights-operator", "cost-mgmt-operator", "marketplace-operator", "acm-operator"}
+		for _, a := range validOperatorAgents {
+			It(fmt.Sprintf("should return a valid Identity json for %s", a), func() {
+				_, ident := call(wrapper, fmt.Sprintf("%s/abc cluster/123", a), "Bearer mytoken")
+				Expect(ident.AccountNumber).To(Equal("123"))
+				Expect(ident.Internal.OrgID).To(Equal("123"))
+				Expect(ident.Type).To(Equal("System"))
+			})
+		}
 	})
 
 	Describe("When called with an invalid user-agent", func() {


### PR DESCRIPTION
To test this PR, start the service locally, and send a curl request:
```
curl http://localhost:8080/api/uhc-auth-proxy/v1/ -A 'foo-operator/blah cluster/123' -H 'Authorization: Bearer foo'
```
You should get a 400 with an error similar to: `Invalid user-agent: 'Invalid user-agent: foo-operator/blah cluster/123'`

Now send a curl with:
```
curl http://localhost:8080/api/uhc-auth-proxy/v1/ -A 'acm-operator/blah cluster/123' -H 'Authorization: Bearer foo'
```
You should see a 401 now regarding the JWT auth not being valid, since it allowed the User Agent.

You can also run the updated unit tests with `go test -v ./...`

---

**Commit 2e5f10e**

https://issues.redhat.com/browse/RHCLOUD-14014

We need to support the following user agent value in 3scale/uhc-auth-proxy:
```
acm-operator/* cluster/*
```

Since the above value will pass the match for supported user agents being treated as `uhc-auth` in the gateway, this should _not_ require any changes there. We will however need to support this in `uhc-auth-proxy`.

This PR adds that support by allowing `acm-operator` as a valid operator prefix, and adds tests to exercise the changes.

---

**Commit 1401a44**

This fixes the following error presented while running tests:
```
./server.go:102:51: conversion from int to string yields a string of one rune, not a string of digits (did you mean fmt.Sprint(x)?)
```

I'm seeing this locally, but not in the latest Travis run, so I'm not sure if it's an environmental issue, but this should be a compatible change.