### PR TITLE
Ensure we check the length of the User Agent before access by index

### DIFF
--- a/server/server.go
+++ b/server/server.go
@@ -58,16 +58,13 @@ var (
 func getClusterID(userAgent string) (string, error) {
 	spl := strings.SplitN(userAgent, " ", 2)
 	validUserAgent := false
+	clusterInAgent := len(spl) >= 2 && strings.HasPrefix(spl[1], `cluster/`)
 	for prefixIdx := range operatorPrefixes {
-		if strings.HasPrefix(spl[0], operatorPrefixes[prefixIdx]) {
+		if strings.HasPrefix(spl[0], operatorPrefixes[prefixIdx]) && clusterInAgent {
 			validUserAgent = true
 		}
 	}
 	if !validUserAgent {
-		return "", fmt.Errorf("Invalid user-agent: %s", userAgent)
-	}
-
-	if !strings.HasPrefix(spl[1], `cluster/`) {
 		return "", fmt.Errorf("Invalid user-agent: %s", userAgent)
 	}
 

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -130,8 +130,14 @@ var _ = Describe("Handler", func() {
 	})
 
 	Describe("When called with an invalid user-agent", func() {
-		It("should not return an identity header", func() {
+		It("should not return an identity header without a supported operator", func() {
 			rr, ident := call(wrapper, "curl", "Bearer mytoken")
+			Expect(rr.Result().StatusCode).To(Equal(400))
+			Expect(ident).To(Equal(&cluster.Identity{}))
+		})
+
+		It("should not return an identity header without a cluster", func() {
+			rr, ident := call(wrapper, "insights-operator/abc", "Bearer mytoken")
 			Expect(rr.Result().StatusCode).To(Equal(400))
 			Expect(ident).To(Equal(&cluster.Identity{}))
 		})


### PR DESCRIPTION
This adds a test to exploit a situation where you can cause the system to panic
and throw a 500, when the User Agent slice does not contain at least two substrings.

For instance, the following will currently cause a panic/500, since the expected
`cluster/` portion of the agent string is missing:

```
curl http://localhost:8080/api/uhc-auth-proxy/v1/ -A 'foo-operator/blah' -H 'Authorization: Bearer foo'

```

This resolves the issue by checking if ` cluster/*` is in the agent prior to
accessing the slice by index. We also remove duplication for returning the same error on the User Agent checks.