### PR TITLE
Remove OAT and post id:token to new endpoint

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -26,7 +26,6 @@ import (
 )
 
 var cfgFile string
-var OfflineAccessToken string
 var ClusterID string
 var AuthorizationToken string
 
@@ -50,7 +49,6 @@ func Execute() {
 
 func init() {
 	cobra.OnInitialize(initConfig)
-	rootCmd.PersistentFlags().StringVar(&OfflineAccessToken, "oat", "", "offline access token used to gain access to the authentication service")
 
 	// Here you will define your flags and configuration settings.
 	// Cobra supports persistent flags, which, if defined here,

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -32,9 +32,7 @@ var runCmd = &cobra.Command{
 cluster_id and authorization_token. This will always refresh the token
 required to access the authentication service.`,
 	Run: func(cmd *cobra.Command, args []string) {
-		wrapper := &client.HTTPWrapper{
-			OfflineAccessToken: OfflineAccessToken,
-		}
+		wrapper := &client.HTTPWrapper{}
 
 		ident, err := cluster.GetIdentity(wrapper, cluster.Registration{
 			ClusterID:          ClusterID,

--- a/cmd/start.go
+++ b/cmd/start.go
@@ -18,7 +18,6 @@ package cmd
 import (
 	"github.com/redhatinsights/uhc-auth-proxy/server"
 	"github.com/spf13/cobra"
-	"github.com/spf13/viper"
 )
 
 // startCmd represents the start command
@@ -26,10 +25,7 @@ var startCmd = &cobra.Command{
 	Use:   "start",
 	Short: "starts the service",
 	Run: func(cmd *cobra.Command, args []string) {
-		if OfflineAccessToken == "" {
-			OfflineAccessToken = viper.GetString("OAT")
-		}
-		server.Start(OfflineAccessToken)
+		server.Start()
 	},
 }
 

--- a/requests/client/wrapper.go
+++ b/requests/client/wrapper.go
@@ -29,30 +29,25 @@ var (
 // HTTPWrapper manages the headers and auth required to speak
 // with the auth service.  It also provides a convenience method
 // to get the bytes from a request.
-type HTTPWrapper struct {
-	OfflineAccessToken string
-}
+type HTTPWrapper struct{}
 
 // Wrapper provides a convenience method for getting bytes from
 // a http request
 type Wrapper interface {
-	Do(req *http.Request, label string) ([]byte, error)
+	Do(req *http.Request, label string, cluster_id string, authorization_token string) ([]byte, error)
 }
 
 // AddHeaders sets the client headers, including the auth token
-func (c *HTTPWrapper) AddHeaders(req *http.Request, token string) {
-	req.Header.Add("Authorization", fmt.Sprintf("Bearer %s", token))
+func (c *HTTPWrapper) AddHeaders(req *http.Request, cluster_id string, authorization_token string) {
+	req.Header.Add("Authorization", fmt.Sprintf("AccessToken %s:%s", cluster_id, authorization_token))
 	req.Header.Add("Accept", "application/json")
 	req.Header.Add("Content-Type", "application/json")
 }
 
 // Do is a convenience wrapper that returns the response bytes
-func (c *HTTPWrapper) Do(req *http.Request, label string) ([]byte, error) {
-	token, err := GetToken(c.OfflineAccessToken)
-	if err != nil {
-		return nil, err
-	}
-	c.AddHeaders(req, token)
+func (c *HTTPWrapper) Do(req *http.Request, label string, cluster_id string, authorization_token string) ([]byte, error) {
+
+	c.AddHeaders(req, cluster_id, authorization_token)
 	start := time.Now()
 	resp, err := client.Do(req)
 	requestTimes.With(prometheus.Labels{"url": label}).Observe(time.Since(start).Seconds())

--- a/requests/cluster/cluster.go
+++ b/requests/cluster/cluster.go
@@ -1,7 +1,6 @@
 package cluster
 
 import (
-	"bytes"
 	"encoding/json"
 	"fmt"
 	"net/http"
@@ -20,88 +19,40 @@ func init() {
 }
 
 // GetIdentity is a facade over all the steps required to get an Identity
-func GetIdentity(wrapper client.Wrapper, r Registration) (*Identity, error) {
-	rr, err := GetAccountID(wrapper, r)
-	if err != nil {
-		return nil, fmt.Errorf("got an err when calling GetAccountID: %s", err)
-	}
+func GetIdentity(wrapper client.Wrapper, reg Registration) (*Identity, error) {
 
-	ar, err := GetAccount(wrapper, rr.AccountID)
+	acct, err := GetCurrentAccount(wrapper, reg)
 	if err != nil {
-		return nil, fmt.Errorf("got an err when calling GetAccount: %s", err)
-	}
-
-	or, err := GetOrg(wrapper, ar.Organization.ID)
-	if err != nil {
-		return nil, fmt.Errorf("got an err when calling GetOrg: %s", err)
+		return nil, fmt.Errorf("got an err when calling GetCurrentAccount: %s", err)
 	}
 
 	return &Identity{
-		AccountNumber: or.EbsAccountID,
+		AccountNumber: acct.Organization.EbsAccountID,
 		Type:          "System",
 		System: map[string]string{
-			"cluster_id": r.ClusterID,
+			"cluster_id": reg.ClusterID,
 		},
 		Internal: Internal{
-			OrgID: or.ExternalID,
+			OrgID: acct.Organization.ExternalID,
 		},
 	}, nil
 }
 
-// GetAccountID requests a cluster registration with the given Request
-func GetAccountID(wrapper client.Wrapper, r Registration) (*ClusterRegistrationResponse, error) {
-	body, err := json.Marshal(r)
+// GetCurrentAccount uses a new flow with direct cluster tokenauth
+func GetCurrentAccount(wrapper client.Wrapper, reg Registration) (*Account, error) {
+	URL := viper.GetString("CURRENT_ACCOUNT_URL")
+
+	req, err := http.NewRequest("GET", URL, nil)
 	if err != nil {
 		return nil, err
 	}
 
-	buf := bytes.NewBuffer(body)
-	URL := viper.GetString("GET_ACCOUNTID_URL")
-	req, err := http.NewRequest("POST", URL, buf)
-	if err != nil {
-		return nil, err
-	}
-
-	b, err := wrapper.Do(req, URL)
-	if err != nil {
-		return nil, err
-	}
-
-	res := &ClusterRegistrationResponse{}
-	if err := json.Unmarshal(b, res); err != nil {
-		return nil, err
-	}
-	return res, nil
-}
-
-// GetAccount retrieves account details
-func GetAccount(wrapper client.Wrapper, accountID string) (*Account, error) {
-	URL := viper.GetString("ACCOUNT_DETAILS_URL")
-	req, _ := http.NewRequest("GET", fmt.Sprintf(URL, accountID), nil)
-
-	b, err := wrapper.Do(req, URL)
+	b, err := wrapper.Do(req, URL, reg.ClusterID, reg.AuthorizationToken)
 	if err != nil {
 		return nil, err
 	}
 
 	res := &Account{}
-	if err := json.Unmarshal(b, res); err != nil {
-		return nil, err
-	}
-	return res, nil
-}
-
-// GetOrg retrieves organization details
-func GetOrg(wrapper client.Wrapper, orgID string) (*Org, error) {
-	URL := viper.GetString("ORG_DETAILS_URL")
-	req, _ := http.NewRequest("GET", fmt.Sprintf(URL, orgID), nil)
-
-	b, err := wrapper.Do(req, URL)
-	if err != nil {
-		return nil, err
-	}
-
-	res := &Org{}
 	if err := json.Unmarshal(b, res); err != nil {
 		return nil, err
 	}

--- a/requests/cluster/cluster_test.go
+++ b/requests/cluster/cluster_test.go
@@ -10,13 +10,11 @@ import (
 var _ = Describe("Cluster", func() {
 
 	var (
-		reg                *Registration
-		ident              *Identity
-		wrapper            *FakeWrapper
-		errWrapper         *ErrorWrapper
-		clusterRegResponse *ClusterRegistrationResponse
-		account            *Account
-		org                *Org
+		reg        *Registration
+		ident      *Identity
+		wrapper    *FakeWrapper
+		errWrapper *ErrorWrapper
+		account    *Account
 	)
 
 	BeforeEach(func() {
@@ -34,41 +32,22 @@ var _ = Describe("Cluster", func() {
 				"cluster_id": "test",
 			},
 		}
-		clusterRegResponse = &ClusterRegistrationResponse{
-			AccountID: "123",
-		}
 		account = &Account{
-			Organization: Organization{
-				ID: "123",
+			Organization: Org{
+				EbsAccountID: "123",
+				ExternalID:   "123",
 			},
 		}
-		org = &Org{
-			EbsAccountID: "123",
-			ExternalID:   "123",
-		}
+
 		wrapper = &FakeWrapper{
-			GetAccountIDResponse: clusterRegResponse,
-			GetAccountResponse:   account,
-			GetOrgResponse:       org,
+			GetAccountResponse: account,
 		}
 		errWrapper = &ErrorWrapper{}
 	})
 
-	Describe("GetAccountID with valid Registration", func() {
-		It("should return a proper cluster registration response", func() {
-			Expect(GetAccountID(wrapper, *reg)).To(Equal(clusterRegResponse))
-		})
-	})
-
-	Describe("GetAccount with valid accountID", func() {
+	Describe("GetCurrentAccount with valid account info", func() {
 		It("should return a proper Account struct", func() {
-			Expect(GetAccount(wrapper, "123")).To(Equal(account))
-		})
-	})
-
-	Describe("GetOrg with valid orgID", func() {
-		It("should return a proper Org struct", func() {
-			Expect(GetOrg(wrapper, "123")).To(Equal(org))
+			Expect(GetCurrentAccount(wrapper, *reg)).To(Equal(account))
 		})
 	})
 

--- a/requests/cluster/config.go
+++ b/requests/cluster/config.go
@@ -6,4 +6,5 @@ func init() {
 	viper.SetDefault("GET_ACCOUNTID_URL", "https://api.openshift.com/api/accounts_mgmt/v1/cluster_registrations")
 	viper.SetDefault("ACCOUNT_DETAILS_URL", "https://api.openshift.com/api/accounts_mgmt/v1/accounts/%s")
 	viper.SetDefault("ORG_DETAILS_URL", "https://api.openshift.com/api/accounts_mgmt/v1/organizations/%s")
+	viper.SetDefault("CURRENT_ACCOUNT_URL", "https://api.openshift.com/api/accounts_mgmt/v1/current_account")
 }

--- a/requests/cluster/types.go
+++ b/requests/cluster/types.go
@@ -15,33 +15,18 @@ type Registration struct {
 	AuthorizationToken string `json:"authorization_token"`
 }
 
-// Response is the format of the cluster registration response
-type ClusterRegistrationResponse struct {
-	ClusterID          string `json:"cluster_id"`
-	AuthorizationToken string `json:"authorization_token"`
-	AccountID          string `json:"account_id"`
-	ExpiresAt          string `json:"expires_at"`
-}
-
-type Organization struct {
-	ID   string `json:"id"`
-	Kind string `json:"kind"`
-	HRef string `json:"href"`
-	Name string `json:"name"`
-}
-
 type Account struct {
-	ID           string       `json:"id"`
-	Kind         string       `json:"kind"`
-	HRef         string       `json:"href"`
-	FirstName    string       `json:"first_name"`
-	LastName     string       `json:"last_name"`
-	Username     string       `json:"username"`
-	Email        string       `json:"email"`
-	Banned       bool         `json:"banned"`
-	CreatedAt    time.Time    `json:"created_at"`
-	UpdatedAt    time.Time    `json:"updated_at"`
-	Organization Organization `json:"organization"`
+	ID           string    `json:"id"`
+	Kind         string    `json:"kind"`
+	HRef         string    `json:"href"`
+	FirstName    string    `json:"first_name"`
+	LastName     string    `json:"last_name"`
+	Username     string    `json:"username"`
+	Email        string    `json:"email"`
+	Banned       bool      `json:"banned"`
+	CreatedAt    time.Time `json:"created_at"`
+	UpdatedAt    time.Time `json:"updated_at"`
+	Organization Org       `json:"organization"`
 }
 
 type Org struct {
@@ -53,11 +38,6 @@ type Org struct {
 	EbsAccountID string    `json:"ebs_account_id"`
 	CreatedAt    time.Time `json:"created_at"`
 	UpdatedAt    time.Time `json:"updated_at"`
-}
-
-type OrgRequest struct {
-	Token string
-	OrgID string
 }
 
 type Internal struct {
@@ -72,21 +52,13 @@ type Identity struct {
 }
 
 type FakeWrapper struct {
-	GetAccountIDResponse *ClusterRegistrationResponse
-	GetAccountResponse   *Account
-	GetOrgResponse       *Org
+	GetAccountResponse *Account
 }
 
-func (f *FakeWrapper) Do(req *http.Request, label string) ([]byte, error) {
+func (f *FakeWrapper) Do(req *http.Request, label string, cluster_id string, authorization_token string) ([]byte, error) {
 	switch req.URL.String() {
-	case viper.GetString("GET_ACCOUNTID_URL"):
-		b, err := json.Marshal(f.GetAccountIDResponse)
-		return b, err
-	case fmt.Sprintf(viper.GetString("ACCOUNT_DETAILS_URL"), "123"):
+	case viper.GetString("CURRENT_ACCOUNT_URL"):
 		b, err := json.Marshal(f.GetAccountResponse)
-		return b, err
-	case fmt.Sprintf(viper.GetString("ORG_DETAILS_URL"), "123"):
-		b, err := json.Marshal(f.GetOrgResponse)
 		return b, err
 	}
 	return nil, fmt.Errorf("FakeClientWrapper failed to handle a case: %s", req.URL.String())
@@ -94,6 +66,6 @@ func (f *FakeWrapper) Do(req *http.Request, label string) ([]byte, error) {
 
 type ErrorWrapper struct{}
 
-func (e *ErrorWrapper) Do(req *http.Request, label string) ([]byte, error) {
+func (e *ErrorWrapper) Do(req *http.Request, label string, cluster_id string, authorization_token string) ([]byte, error) {
 	return nil, fmt.Errorf("errWrapper for: %s", req.URL.String())
 }

--- a/server/server.go
+++ b/server/server.go
@@ -66,7 +66,7 @@ func getClusterID(userAgent string) (string, error) {
 		}
 	}
 	if !validUserAgent {
-		return "", fmt.Errorf("Invalid user-agent: %s", userAgent)
+		return "", fmt.Errorf("invalid user-agent: %s", userAgent)
 	}
 
 	return strings.TrimPrefix(spl[1], `cluster/`), nil
@@ -74,7 +74,7 @@ func getClusterID(userAgent string) (string, error) {
 
 func getToken(authorizationHeader string) (string, error) {
 	if !strings.HasPrefix(authorizationHeader, `Bearer `) {
-		return "", fmt.Errorf("Not a bearer token: '%s'", authorizationHeader)
+		return "", fmt.Errorf("not a bearer token: '%s'", authorizationHeader)
 	}
 
 	return strings.TrimPrefix(authorizationHeader, `Bearer `), nil
@@ -165,7 +165,7 @@ func StatusHandler(w http.ResponseWriter, r *http.Request) {
 }
 
 // Start starts the server
-func Start(offlineAccessToken string) {
+func Start() {
 	r := chi.NewRouter()
 	r.Use(
 		request_id.ConfiguredRequestID("x-rh-insights-request-id"),
@@ -175,9 +175,7 @@ func Start(offlineAccessToken string) {
 		middleware.StripSlashes,
 	)
 
-	wrapper := &client.HTTPWrapper{
-		OfflineAccessToken: offlineAccessToken,
-	}
+	wrapper := &client.HTTPWrapper{}
 
 	handler := RootHandler(wrapper)
 

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -2,10 +2,10 @@ package server
 
 import (
 	"encoding/json"
+	"fmt"
 	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
-	"fmt"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
@@ -94,29 +94,19 @@ var _ = Describe("HandlerWithBadWrapper", func() {
 var _ = Describe("Handler", func() {
 
 	var (
-		wrapper            *cluster.FakeWrapper
-		clusterRegResponse *cluster.ClusterRegistrationResponse
-		account            *cluster.Account
-		org                *cluster.Org
+		wrapper *cluster.FakeWrapper
+		account *cluster.Account
 	)
 
 	BeforeEach(func() {
-		clusterRegResponse = &cluster.ClusterRegistrationResponse{
-			AccountID: "123",
-		}
 		account = &cluster.Account{
-			Organization: cluster.Organization{
-				ID: "123",
+			Organization: cluster.Org{
+				EbsAccountID: "123",
+				ExternalID:   "123",
 			},
 		}
-		org = &cluster.Org{
-			EbsAccountID: "123",
-			ExternalID:   "123",
-		}
 		wrapper = &cluster.FakeWrapper{
-			GetAccountIDResponse: clusterRegResponse,
-			GetAccountResponse:   account,
-			GetOrgResponse:       org,
+			GetAccountResponse: account,
 		}
 		cache.Clear()
 	})


### PR DESCRIPTION
Big commit here, but it's all part of the same work. OCM has set up a
new tokenauth endpoint for us that will accept posts of a cluster id and
auth token. This will both clean up their metrics and drop our required
API calls from three to one to get the same data.

Signed-off-by: Chris Mitchell <cmitchel@redhat.com>