### PR TITLE
Manually Triggering Image Build and Unit Test Update

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-# Manual Build: 2021-08-06
+# Manual Build: 2022-03-10
 ############################
 # STEP 1 build executable binary
 ############################

--- a/unit_test.sh
+++ b/unit_test.sh
@@ -11,8 +11,8 @@ source .bonfire_venv/bin/activate
 
 # If your unit tests store junit xml results, you should store them in a file matching format `artifacts/junit-*.xml`
 # If you have no junit file, use the below code to create a 'dummy' result file so Jenkins will not fail
-mkdir -p $WORKSPACE/artifacts
-cat << EOF > $WORKSPACE/artifacts/junit-dummy.xml
+mkdir -p $ARTIFACTS_DIR
+cat << EOF > $ARTIFACTS_DIR/junit-dummy.xml
 <testsuite tests="1">
     <testcase classname="dummy" name="dummytest"/>
 </testsuite>

--- a/unit_test.sh
+++ b/unit_test.sh
@@ -6,15 +6,19 @@ export GO111MODULE="on"
 go test -v -race -covermode=atomic ./...
 result=$?
 
-if [ $result != 0 ]; then
-    exit $result
-else
-    # If your unit tests store junit xml results, you should store them in a file matching format `artifacts/junit-*.xml`
-    # If you have no junit file, use the below code to create a 'dummy' result file so Jenkins will not fail
-    mkdir -p $WORKSPACE/artifacts
-    cat << EOF > $WORKSPACE/artifacts/junit-dummy.xml
-    <testsuite tests="1">
-        <testcase classname="dummy" name="dummytest"/>
-    </testsuite>
+
+# If your unit tests store junit xml results, you should store them in a file matching format `artifacts/junit-*.xml`
+# If you have no junit file, use the below code to create a 'dummy' result file so Jenkins will not fail
+mkdir -p $WORKSPACE/artifacts
+cat << EOF > $WORKSPACE/artifacts/junit-dummy.xml
+<testsuite tests="1">
+    <testcase classname="dummy" name="dummytest"/>
+</testsuite>
 EOF
+
+if [ $result -ne 0 ]; then
+  echo '====================================='
+  echo '====  ✖ ERROR: UNIT TEST FAILED  ===='
+  echo '====================================='
+  exit 1
 fi

--- a/unit_test.sh
+++ b/unit_test.sh
@@ -6,6 +6,8 @@ export GO111MODULE="on"
 go test -v -race -covermode=atomic ./...
 result=$?
 
+# Move to the bonfire virtual env
+source .bonfire_venv/bin/activate
 
 # If your unit tests store junit xml results, you should store them in a file matching format `artifacts/junit-*.xml`
 # If you have no junit file, use the below code to create a 'dummy' result file so Jenkins will not fail


### PR DESCRIPTION
#### Jira Ticket: https://issues.redhat.com/browse/RHCLOUD-18295
---

- Updating the `Manual Build` comment within the `Dockerfile` to trigger a new image to be created in Quay.
- Additionally, I updated the `unit_test.sh` based on the newest build of Bonfire. So it is working again.