### PR TITLE
Add top level org id support

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ An identification document should look something like this:
 
     {
          "account_number": "123456",
+         "org_id": "1234567",
          "type": "System",
          "internal": {
              "org_id": "1234567"
@@ -98,7 +99,7 @@ Example of a curl call to local deployment:
 
 ## Open Endpoints
 
-There are three open endpoints that could be reached. 
+There are three open endpoints that could be reached.
 
 `/api/uhc-auth-proxy/v1`
 

--- a/requests/cluster/cluster.go
+++ b/requests/cluster/cluster.go
@@ -28,6 +28,7 @@ func GetIdentity(wrapper client.Wrapper, reg Registration) (*Identity, error) {
 
 	return &Identity{
 		AccountNumber: acct.Organization.EbsAccountID,
+		OrgID:         acct.Organization.ExternalID,
 		Type:          "System",
 		System: map[string]string{
 			"cluster_id": reg.ClusterID,

--- a/requests/cluster/cluster_test.go
+++ b/requests/cluster/cluster_test.go
@@ -24,6 +24,7 @@ var _ = Describe("Cluster", func() {
 		}
 		ident = &Identity{
 			AccountNumber: "123",
+			OrgID:         "123",
 			Type:          "System",
 			Internal: Internal{
 				OrgID: "123",

--- a/requests/cluster/types.go
+++ b/requests/cluster/types.go
@@ -46,6 +46,7 @@ type Internal struct {
 
 type Identity struct {
 	AccountNumber string            `json:"account_number"`
+	OrgID string                    `json:"org_id"`
 	Type          string            `json:"type"`
 	Internal      Internal          `json:"internal"`
 	System        map[string]string `json:"system,omitempty"`


### PR DESCRIPTION
- [Ensure we add the org_id in the top level of the UHC-auth identity](https://github.com/RedHatInsights/uhc-auth-proxy/commit/2260e14adc92facf5c2a2c76d88cd0191617fa16)

- [Add org_id to the README identity example](https://github.com/RedHatInsights/uhc-auth-proxy/commit/5d63012d368280beab814ff65747bc42293718c4)