### PR TITLE
Add `assisted-installer-operator/*` User-Agent

### DIFF
--- a/server/server.go
+++ b/server/server.go
@@ -44,14 +44,15 @@ var (
 )
 
 const (
-	insightsOperatorPrefix    = `insights-operator/`
-	costMgmtOperatorPrefix    = `cost-mgmt-operator/`
-	marketplaceOperatorPrefix = `marketplace-operator/`
-	acmOperator               = `acm-operator/`
+	insightsOperatorPrefix          = `insights-operator/`
+	costMgmtOperatorPrefix          = `cost-mgmt-operator/`
+	marketplaceOperatorPrefix       = `marketplace-operator/`
+	acmOperator                     = `acm-operator/`
+	assistedInstallerOperatorPrefix = `assisted-installer-operator/`
 )
 
 var (
-	operatorPrefixes = [4]string{insightsOperatorPrefix, costMgmtOperatorPrefix, marketplaceOperatorPrefix, acmOperator}
+	operatorPrefixes = [5]string{insightsOperatorPrefix, costMgmtOperatorPrefix, marketplaceOperatorPrefix, acmOperator, assistedInstallerOperatorPrefix}
 )
 
 // returns the cluster id from the user agent string used by the support operator

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -112,7 +112,7 @@ var _ = Describe("Handler", func() {
 	})
 
 	Describe("When called with a valid request", func() {
-		validOperatorAgents := []string{"insights-operator", "cost-mgmt-operator", "marketplace-operator", "acm-operator"}
+		validOperatorAgents := []string{"insights-operator", "cost-mgmt-operator", "marketplace-operator", "acm-operator", "assisted-installer-operator"}
 		for _, a := range validOperatorAgents {
 			It(fmt.Sprintf("should return a valid Identity json for %s", a), func() {
 				_, ident := call(wrapper, fmt.Sprintf("%s/abc cluster/123", a), "Bearer mytoken")


### PR DESCRIPTION
This PR adds that support by allowing `assisted-installer-operator` as a valid operator prefix, and adds tests to exercise the changes.

Part of the effort to collect on-premises data from assisted-service https://issues.redhat.com/browse/MGMT-12483
Epic: https://issues.redhat.com/browse/MGMT-10308
