### PR TITLE
Add Cryostat Operator User-Agent

### DIFF
--- a/server/server.go
+++ b/server/server.go
@@ -49,10 +49,11 @@ const (
 	marketplaceOperatorPrefix       = `marketplace-operator/`
 	acmOperator                     = `acm-operator/`
 	assistedInstallerOperatorPrefix = `assisted-installer-operator/`
+	cryostatOperatorPrefix          = `cryostat-operator/`
 )
 
 var (
-	operatorPrefixes = [5]string{insightsOperatorPrefix, costMgmtOperatorPrefix, marketplaceOperatorPrefix, acmOperator, assistedInstallerOperatorPrefix}
+	operatorPrefixes = [6]string{insightsOperatorPrefix, costMgmtOperatorPrefix, marketplaceOperatorPrefix, acmOperator, assistedInstallerOperatorPrefix, cryostatOperatorPrefix}
 )
 
 // returns the cluster id from the user agent string used by the support operator

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -142,7 +142,7 @@ var _ = Describe("Handler", func() {
 	})
 
 	Describe("When called with a valid request", func() {
-		validOperatorAgents := []string{"insights-operator", "cost-mgmt-operator", "marketplace-operator", "acm-operator", "assisted-installer-operator"}
+		validOperatorAgents := []string{"insights-operator", "cost-mgmt-operator", "marketplace-operator", "acm-operator", "assisted-installer-operator", "cryostat-operator"}
 		for _, a := range validOperatorAgents {
 			It(fmt.Sprintf("should return a valid Identity json for %s", a), func() {
 				_, ident := call(wrapper, fmt.Sprintf("%s/abc cluster/123", a), "Bearer mytoken")


### PR DESCRIPTION
This PR adds the [Cryostat Operator](https://github.com/cryostatio/cryostat-operator) as an accepted prefix for a User-Agent string. In addition to its primary purpose as a JDK Flight Recorder based profiling and monitoring tool, an upcoming release of the Red Hat build of Cryostat adds support to assist sending reports to Red Hat Insights for Red Hat Runtimes products. [1]

As part of this support, the Cryostat Operator acts as a proxy. It receives payloads from Java agents deployed across the cluster and forwards them to Insights using the cluster's `cloud.openshift.com` token and cluster ID.

[1] https://github.com/RedHatInsights/insights-java-client