### PR TITLE
[RHCLOUD-32450] use the latest ubi9/go-toolset and ubi9/ubi-minimal in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@
 ############################
 # STEP 1 build executable binary
 ############################
-FROM registry.access.redhat.com/ubi8/go-toolset:latest AS builder
+FROM registry.access.redhat.com/ubi9/go-toolset:latest AS builder
 WORKDIR $GOPATH/src/mypackage/myapp/
 COPY . .
 # Fetch dependencies.
@@ -14,7 +14,7 @@ RUN CGO_ENABLED=0 go build -o /go/bin/uhc-auth-proxy
 ############################
 # STEP 2 build a small image
 ############################
-FROM registry.access.redhat.com/ubi8/ubi-minimal:latest
+FROM registry.access.redhat.com/ubi9/ubi-minimal:latest
 # Copy our static executable.
 COPY --from=builder /go/bin/uhc-auth-proxy /go/bin/uhc-auth-proxy
 # Default port


### PR DESCRIPTION
Jira [RHCLOUD-32450](https://issues.redhat.com/browse/RHCLOUD-32450)

use the ubi9 images to solve the vulnerability in ubi8
```
quay.io/cloudservices/uhc-auth-proxy:d599035
NAME    INSTALLED         FIXED-IN            TYPE  VULNERABILITY   SEVERITY 
gnutls  3.6.16-8.el8_9.1  0:3.6.16-8.el8_9.3  rpm   CVE-2024-28834  Medium
```

with ubi9 (tested locally)
```
$ podman build -t uhc-auth-proxy:v1 .
...
$ grype --only-fixed localhost/uhc-auth-proxy:v1
...
No vulnerabilities found
```
