### PR TITLE
[RHCLOUD-32450] Revert "use the latest ubi9/go-toolset and ubi9/ubi-minimal in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@
 ############################
 # STEP 1 build executable binary
 ############################
-FROM registry.access.redhat.com/ubi9/go-toolset:latest AS builder
+FROM registry.access.redhat.com/ubi8/go-toolset:latest AS builder
 WORKDIR $GOPATH/src/mypackage/myapp/
 COPY . .
 # Fetch dependencies.
@@ -14,7 +14,7 @@ RUN CGO_ENABLED=0 go build -o /go/bin/uhc-auth-proxy
 ############################
 # STEP 2 build a small image
 ############################
-FROM registry.access.redhat.com/ubi9/ubi-minimal:latest
+FROM registry.access.redhat.com/ubi8/ubi-minimal:latest
 # Copy our static executable.
 COPY --from=builder /go/bin/uhc-auth-proxy /go/bin/uhc-auth-proxy
 # Default port


### PR DESCRIPTION
This reverts commit 3be8d87af904f288a5cb3fe3f4d944f111053974
https://github.com/RedHatInsights/uhc-auth-proxy/pull/57
[RHCLOUD-32450](https://issues.redhat.com/browse/RHCLOUD-32450)
we cannot use ubi9 because the ubi8 is only one base image approved by our federal customers