### PR TITLE
[RHCLOUD-32616] updated limits and requests for cpu and memory for uhc auth proxy containers

### DIFF
--- a/openshift/uhc-auth-proxy-template.yaml
+++ b/openshift/uhc-auth-proxy-template.yaml
@@ -2,21 +2,6 @@ apiVersion: v1
 kind: Template
 metadata:
   name: uhc-auth-proxy-template
-parameters:
-- name: REGISTRY_IMG
-  required: true
-- name: CHANNEL
-  value: staging
-- name: IMAGE_TAG
-  value: latest
-- name: OPENSHIFT_API_TARGET
-  value: https://api.openshift.com/api/accounts_mgmt/v1/current_account
-- name: REPLICAS
-  description: The number of replicas to use in the deployment
-  value: '1'
-- name: LOG_LEVEL
-  required: true
-  value: INFO
 objects:
 - apiVersion: apps/v1
   kind: Deployment
@@ -123,11 +108,11 @@ objects:
             timeoutSeconds: 60
           resources:
             limits:
-              cpu: 500m
-              memory: 500Mi
+              cpu: ${CPU_LIMIT} 
+              memory: ${MEMORY_LIMIT}
             requests:
-              cpu: 100m
-              memory: 250Mi
+              cpu: ${CPU_REQUESTS}
+              memory: ${MEMORY_REQUESTS}
           terminationMessagePath: /dev/termination-log
           terminationMessagePolicy: File
         dnsPolicy: ClusterFirst
@@ -155,3 +140,30 @@ objects:
       app: uhc-auth-proxy
     sessionAffinity: None
     type: ClusterIP
+parameters:
+- name: REGISTRY_IMG
+  required: true
+- name: CHANNEL
+  value: staging
+- name: IMAGE_TAG
+  value: latest
+- name: OPENSHIFT_API_TARGET
+  value: https://api.openshift.com/api/accounts_mgmt/v1/current_account
+- name: REPLICAS
+  description: The number of replicas to use in the deployment
+  value: '1'
+- name: LOG_LEVEL
+  required: true
+  value: INFO
+  - description: cpu limit for service
+  name: CPU_LIMIT
+  value: 250m
+- description: memory limit for service
+  name: MEMORY_LIMIT
+  value: 400Mi
+- description: requested cpu for service
+  name: CPU_REQUESTS
+  value: 50m
+- description: requested memory for service
+  name: MEMORY_REQUESTS
+  value: 200Mi


### PR DESCRIPTION
[RHCLOUD-32616](https://issues.redhat.com/browse/RHCLOUD-32616)

according long term observation we can lower limits and requests values for cpu and memory

![image](https://github.com/RedHatInsights/uhc-auth-proxy/assets/89980168/cf626468-cd16-4462-96c7-b4af672f84f4)
https://grafana.stage.devshift.net/d/HXbU7G1Iz/aandm-resources-health?orgId=1&from=now-7d&to=now&var-Datasource=crcp01ue1-prometheus

