### PR TITLE
[RHCLOUD-32987] updated limit and request for cpu resource

### DIFF
--- a/openshift/uhc-auth-proxy-template.yaml
+++ b/openshift/uhc-auth-proxy-template.yaml
@@ -157,13 +157,13 @@ parameters:
   value: INFO
 - description: cpu limit for service
   name: CPU_LIMIT
-  value: 250m
+  value: 150m
 - description: memory limit for service
   name: MEMORY_LIMIT
   value: 400Mi
 - description: requested cpu for service
   name: CPU_REQUESTS
-  value: 50m
+  value: 25m
 - description: requested memory for service
   name: MEMORY_REQUESTS
   value: 200Mi


### PR DESCRIPTION
[RHCLOUD-32987](https://issues.redhat.com/browse/RHCLOUD-32987)

our cpu limit utilisation is 2 %, I think we can update the values a little bit
https://grafana.stage.devshift.net/d/R-Q6WgAIz/insights-resource-queries?orgId=1&from=now-7d&to=now&var-datasource=P5FEA9F8380B21C0A&var-namespace=uhc-auth-proxy-prod&var-pod=All&var-rds_datasource=P465885893AA82E04&var-db_instance=
