### PR TITLE
[RHCLOUD-33914] change ioutil.ReadAll into io.ReadAll

### DIFF
--- a/requests/client/access.go
+++ b/requests/client/access.go
@@ -3,7 +3,7 @@ package client
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/url"
 	"sync"
 	"time"
@@ -30,7 +30,7 @@ func fetch(offlineAccessToken string) (*response, error) {
 		return nil, err
 	}
 
-	body, err := ioutil.ReadAll(resp.Body)
+	body, err := io.ReadAll(resp.Body)
 	resp.Body.Close()
 	if err != nil {
 		return nil, err

--- a/requests/client/wrapper.go
+++ b/requests/client/wrapper.go
@@ -2,7 +2,7 @@ package client
 
 import (
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"strconv"
 	"time"
@@ -62,7 +62,7 @@ func (c *HTTPWrapper) Do(req *http.Request, label string, cluster_id string, aut
 	}
 	defer resp.Body.Close()
 
-	b, err := ioutil.ReadAll(resp.Body)
+	b, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return nil, err
 	}

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -3,7 +3,7 @@ package server
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/http/httptest"
 
@@ -66,7 +66,7 @@ func call(wrapper client.Wrapper, userAgent string, auth string) (*httptest.Resp
 	rr := httptest.NewRecorder()
 	handler := RootHandler(wrapper)
 	handler(rr, req)
-	out, err := ioutil.ReadAll(rr.Result().Body)
+	out, err := io.ReadAll(rr.Result().Body)
 	Expect(err).To(BeNil())
 	rr.Result().Body.Close()
 	var ident cluster.Identity
@@ -113,7 +113,7 @@ var _ = Describe("HandlerWithBadWrapper", func() {
 			}
 
 			rr, _ := call(errWithBodyWrapper, "insights-operator/abc cluster/123", "Bearer errmytoken")
-			body, _ := ioutil.ReadAll(rr.Body)
+			body, _ := io.ReadAll(rr.Body)
 			Expect(string(body)).To(ContainSubstring("descriptive reason"))
 			Expect(string(body)).To(ContainSubstring("bad code"))
 			Expect(string(body)).To(ContainSubstring("bad id"))


### PR DESCRIPTION
[RHCLOUD-33914](https://issues.redhat.com/browse/RHCLOUD-33914)

ioutil.ReadAll is deprecated: As of Go 1.16, this function simply calls io.ReadAll. https://pkg.go.dev/io/ioutil#ReadAll