### PR TITLE
Set up source build image for konflux migration

### DIFF
--- a/.tekton/uhc-auth-proxy-pull-request.yaml
+++ b/.tekton/uhc-auth-proxy-pull-request.yaml
@@ -112,7 +112,7 @@ spec:
       description: Image tag expiration time, time values could be something like
         1h, 2d, 3w for hours, days, and weeks, respectively.
       name: image-expires-after
-    - default: "false"
+    - default: "true"
       description: Build a source image.
       name: build-source-image
       type: string

--- a/.tekton/uhc-auth-proxy-pull-request.yaml
+++ b/.tekton/uhc-auth-proxy-pull-request.yaml
@@ -372,7 +372,7 @@ spec:
         - name: name
           value: clamav-scan
         - name: bundle
-          value: quay.io/redhat-appstudio-tekton-catalog/task-clamav-scan:0.1@sha256:45deb2d3cc6a23166831c7471882a0c8cc8a754365e0598e3e2022cbb1866375
+          value: quay.io/konflux-ci/tekton-catalog/task-clamav-scan:0.1@sha256:46fcff23fd21772572c5fd62f6bbaf8fa2913d3d464c685bf7a2d0da05a448c0
         - name: kind
           value: task
         resolver: bundles

--- a/.tekton/uhc-auth-proxy-pull-request.yaml
+++ b/.tekton/uhc-auth-proxy-pull-request.yaml
@@ -372,7 +372,7 @@ spec:
         - name: name
           value: clamav-scan
         - name: bundle
-          value: quay.io/redhat-appstudio-tekton-catalog/task-clamav-scan:0.1@sha256:5dbe6c646c3502ddc7fbe6016b8584bed6ce3ab7028b0c405ebaabc7e6e9e64c
+          value: quay.io/redhat-appstudio-tekton-catalog/task-clamav-scan:0.1@sha256:45deb2d3cc6a23166831c7471882a0c8cc8a754365e0598e3e2022cbb1866375
         - name: kind
           value: task
         resolver: bundles

--- a/.tekton/uhc-auth-proxy-push.yaml
+++ b/.tekton/uhc-auth-proxy-push.yaml
@@ -109,7 +109,7 @@ spec:
       description: Image tag expiration time, time values could be something like
         1h, 2d, 3w for hours, days, and weeks, respectively.
       name: image-expires-after
-    - default: "false"
+    - default: "true"
       description: Build a source image.
       name: build-source-image
       type: string

--- a/.tekton/uhc-auth-proxy-push.yaml
+++ b/.tekton/uhc-auth-proxy-push.yaml
@@ -369,7 +369,7 @@ spec:
         - name: name
           value: clamav-scan
         - name: bundle
-          value: quay.io/redhat-appstudio-tekton-catalog/task-clamav-scan:0.1@sha256:5dbe6c646c3502ddc7fbe6016b8584bed6ce3ab7028b0c405ebaabc7e6e9e64c
+          value: quay.io/redhat-appstudio-tekton-catalog/task-clamav-scan:0.1@sha256:45deb2d3cc6a23166831c7471882a0c8cc8a754365e0598e3e2022cbb1866375
         - name: kind
           value: task
         resolver: bundles

--- a/.tekton/uhc-auth-proxy-push.yaml
+++ b/.tekton/uhc-auth-proxy-push.yaml
@@ -369,7 +369,7 @@ spec:
         - name: name
           value: clamav-scan
         - name: bundle
-          value: quay.io/redhat-appstudio-tekton-catalog/task-clamav-scan:0.1@sha256:45deb2d3cc6a23166831c7471882a0c8cc8a754365e0598e3e2022cbb1866375
+          value: quay.io/konflux-ci/tekton-catalog/task-clamav-scan:0.1@sha256:46fcff23fd21772572c5fd62f6bbaf8fa2913d3d464c685bf7a2d0da05a448c0
         - name: kind
           value: task
         resolver: bundles


### PR DESCRIPTION
Referenced doc: https://gitlab.cee.redhat.com/konflux/docs/users/-/blob/main/topics/getting-started/components-applications.md#set-up-source-build-image 

> Per the Red Hat policy, you will need to update the pipeline to build source images. For doing that, you should change the build-source-image parameter in both pipelines (push and pull-request) default value to “true”.