### PR TITLE
[RHCLOUD-36127] upgrade github.com/aws/aws-sdk-go package to the latest version

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@ module github.com/redhatinsights/uhc-auth-proxy
 
 require (
 	github.com/RedHatInsights/cloudwatch v0.0.0-20210111105023-1df2bdfe3291
-	github.com/aws/aws-sdk-go v1.49.13
+	github.com/aws/aws-sdk-go v1.55.5
 	github.com/go-chi/chi/v5 v5.1.0
 	github.com/mitchellh/go-homedir v1.1.0
 	github.com/onsi/ginkgo v1.16.5

--- a/go.sum
+++ b/go.sum
@@ -8,8 +8,9 @@ github.com/alecthomas/template v0.0.0-20160405071501-a0175ee3bccc/go.mod h1:LOuy
 github.com/alecthomas/units v0.0.0-20151022065526-2efee857e7cf/go.mod h1:ybxpYRFXyAe+OPACYpWeL0wqObRcbAqCMya13uyzqw0=
 github.com/armon/consul-api v0.0.0-20180202201655-eb2c6b5be1b6/go.mod h1:grANhF5doyWs3UAsr3K4I6qtAmlQcZDesFNEHPZAzj8=
 github.com/aws/aws-sdk-go v1.30.11/go.mod h1:5zCpMtNQVjRREroY7sYe8lOMRSxkhG6MZveU8YkpAk0=
-github.com/aws/aws-sdk-go v1.49.13 h1:f4mGztsgnx2dR9r8FQYa9YW/RsKb+N7bgef4UGrOW1Y=
 github.com/aws/aws-sdk-go v1.49.13/go.mod h1:LF8svs817+Nz+DmiMQKTO3ubZ/6IaTpq3TjupRn3Eqk=
+github.com/aws/aws-sdk-go v1.55.5 h1:KKUZBfBoyqy5d3swXyiC7Q76ic40rYcbqH7qjh59kzU=
+github.com/aws/aws-sdk-go v1.55.5/go.mod h1:eRwEWoyTWFMVYVQzKMNHWP5/RV4xIUGMQfXQHfHkpNU=
 github.com/beorn7/perks v0.0.0-20180321164747-3a771d992973/go.mod h1:Dwedo/Wpr24TaqPxmxbtue+5NUziq4I4S80YR8gNf3Q=
 github.com/beorn7/perks v1.0.0/go.mod h1:KWe93zE9D1o94FZ5RNwFwVgaQK1VOXiVxmqh+CedLV8=
 github.com/beorn7/perks v1.0.1 h1:VlbKKnNfV8bJzeqoa4cOKqO6bYr3WgKZxO8Z16+hsOM=


### PR DESCRIPTION
[RHCLOUD-36127](https://issues.redhat.com/browse/RHCLOUD-36127)

upgrade `github.com/aws/aws-sdk-go` package to the latest version => generate new image with latest base image and fix some vulnerabilities

```
NAME          INSTALLED          FIXED-IN            TYPE       VULNERABILITY   SEVERITY 
bzip2-libs    1.0.6-26.el8       0:1.0.6-27.el8_10   rpm        CVE-2019-12900  Low       
krb5-libs     1.18.2-29.el8_10   0:1.18.2-30.el8_10  rpm        CVE-2024-3596   High      
openssl-libs  1:1.1.1k-12.el8_9  1:1.1.1k-14.el8_6   rpm        CVE-2024-5535   Low       
stdlib        go1.21.13          1.22.7, 1.23.1      go-module  CVE-2024-34158  High      
stdlib        go1.21.13          1.22.7, 1.23.1      go-module  CVE-2024-34156  High      
stdlib        go1.21.13          1.22.7, 1.23.1      go-module  CVE-2024-34155  Medium
```