### PR TITLE
[RHCLOUD-32031] update dockerignore

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,1 +1,12 @@
-.git
+# Ignore everything
+*
+
+# ... except for
+!cache/
+!cmd/
+!logger/
+!requests/
+!server/
+!go.mod
+!go.sum
+!main.go


### PR DESCRIPTION
[RHCLOUD-32031](https://issues.redhat.com/browse/RHCLOUD-32031)

one of recommendations in [Credential Leak Self Assessment](https://docs.google.com/document/d/1IsX7NmMnWPcuOseyjjUj_T9VjBXx7p3UjWs5eNpDHyI/edit?tab=t.0) document is to add `.dockerignore` file into repository and not ignore only files and folders that are needed