### PR TITLE
migrate to the ubi9/ubi-minimal base image in the tekton config

### DIFF
--- a/.tekton/uhc-auth-proxy-pull-request.yaml
+++ b/.tekton/uhc-auth-proxy-pull-request.yaml
@@ -217,7 +217,7 @@ spec:
           # set the working directory to value from previous step
           workingDir: /var/workdir/source
           # Use image that suites your use case
-          image: registry.access.redhat.com/ubi8/go-toolset:1.22.9-2.1738756484
+          image: registry.access.redhat.com/ubi9/go-toolset:9.5-1739801907
           securityContext:
           # If the task step needs write access to the volume, set the runAsUser to 0 (root).
             runAsUser: 0


### PR DESCRIPTION
we migrated into ubi9 here https://github.com/RedHatInsights/uhc-auth-proxy/pull/125
but forgot to update the tekton config too