### PR TITLE
[RHCLOUD-38634] upgrade go version into 1.22.9 (latest in the ubi9/go-toolset base image)

### DIFF
--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -18,7 +18,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5
         with:
-          go-version: '1.21'
+          go-version: '1.22.9'
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v6
         with:

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/redhatinsights/uhc-auth-proxy
 
-go 1.21
+go 1.22.9
 
 require (
 	github.com/RedHatInsights/cloudwatch v0.0.0-20210111105023-1df2bdfe3291


### PR DESCRIPTION
[RHCLOUD-38634](https://issues.redhat.com/browse/RHCLOUD-38634)