### PR TITLE
bump golang version into 1.23.6

### DIFF
--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -18,7 +18,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5
         with:
-          go-version: '1.22.9'
+          go-version: '1.23.6'
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v6
         with:

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/redhatinsights/uhc-auth-proxy
 
-go 1.22.9
+go 1.23.6
 
 require (
 	github.com/RedHatInsights/cloudwatch v0.0.0-20210111105023-1df2bdfe3291

--- a/unit_test.sh
+++ b/unit_test.sh
@@ -3,6 +3,7 @@
 set -exv
 
 export GO111MODULE="on"
+export GOTOOLCHAIN="auto"
 go test -v -race --coverprofile=coverage.txt --covermode=atomic ./...
 result=$?
 


### PR DESCRIPTION
## Summary by Sourcery

Update Go version to 1.23.6 in project configuration files

Build:
- Update go.mod to specify Go version 1.23.6

CI:
- Update GitHub Actions workflow to use Go version 1.23.6