### PR TITLE
bump base image ubi9/go-goolset to the latest version

### DIFF
--- a/.tekton/uhc-auth-proxy-pull-request.yaml
+++ b/.tekton/uhc-auth-proxy-pull-request.yaml
@@ -217,7 +217,7 @@ spec:
           # set the working directory to value from previous step
           workingDir: /var/workdir/source
           # Use image that suites your use case
-          image: registry.access.redhat.com/ubi9/go-toolset:9.5-1743582279
+          image: registry.access.redhat.com/ubi9/go-toolset:9.5-1745328278
           securityContext:
           # If the task step needs write access to the volume, set the runAsUser to 0 (root).
             runAsUser: 0

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@
 ############################
 # STEP 1 build executable binary
 ############################
-FROM registry.access.redhat.com/ubi9/go-toolset:9.5-1743582279 AS builder
+FROM registry.access.redhat.com/ubi9/go-toolset:9.5-1745328278 AS builder
 WORKDIR $GOPATH/src/mypackage/myapp/
 COPY . .
 # Fetch dependencies.


### PR DESCRIPTION
## Summary by Sourcery

Build:
- Upgraded the base UBI9 Go toolset image from version 9.5-1743582279 to 9.5-1745328278 in both Dockerfile and Tekton pipeline configuration