### PR TITLE
update 'task-git-clone-oci-ta' ref to the latest version

### DIFF
--- a/.tekton/uhc-auth-proxy-pull-request.yaml
+++ b/.tekton/uhc-auth-proxy-pull-request.yaml
@@ -173,7 +173,7 @@ spec:
         - name: name
           value: git-clone-oci-ta
         - name: bundle
-          value: quay.io/konflux-ci/tekton-catalog/task-git-clone-oci-ta@sha256:0f4360ce144d46171ebd2e8f4d4575539a0600e02208ba5fc9beeb2c27ddfd4c
+          value: quay.io/konflux-ci/tekton-catalog/task-git-clone-oci-ta:0.1@sha256:d35e5d501cb5f5f88369511f76249857cb5ac30250e1dcf086939321964ff6b9
         - name: kind
           value: task
         resolver: bundles


### PR DESCRIPTION
`enterprise-contract `pipeline is failing because of 

```
✕ [Violation] tasks.required_untrusted_task_found
  ImageRef: quay.io/redhat-user-workloads/hcc-accessmanagement-tenant/uhc-auth-proxy/uhc-auth-proxy@sha256:da2b6605a709316d5dd05a7c4fed5ee97b7ee773f2c0db3b0ed76c16bbbaba6c
  Reason: Required task "git-clone-oci-ta" is required and present but not from a trusted task
  Term: git-clone-oci-ta
  Title: All required tasks are from trusted tasks
  Description: Ensure that the all required tasks are resolved from trusted tasks. To exclude this rule add
  "tasks.required_untrusted_task_found:git-clone-oci-ta" to the `exclude` section of the policy configuration.
  Solution: Make sure all required tasks in the build pipeline are resolved from trusted tasks.
```