### PR TITLE
Updating REGISTRY_IMG to try to fix the bonfire-tekton pipelines

### DIFF
--- a/openshift/uhc-auth-proxy-template.yaml
+++ b/openshift/uhc-auth-proxy-template.yaml
@@ -142,7 +142,7 @@ objects:
     type: ClusterIP
 parameters:
 - name: REGISTRY_IMG
-  required: true
+  required: false
 - name: CHANNEL
   value: staging
 - name: IMAGE_TAG


### PR DESCRIPTION
Currently, in app interface, the parameter here is overriding the image parameter. I want to try removing the parameter to see whether or not it'll fix the bonfire-tekton pipelines and see if the correct images are being overriden. 

Related link: https://gitlab.cee.redhat.com/service/app-interface/-/blob/master/data/services/insights/uhc-auth-proxy/deploy.yml?ref_type=heads#L38