### PR TITLE
Add agent-readiness documentation layer

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,0 +1,6 @@
+# yaml-language-server: $schema=https://coderabbit.ai/integrations/schema.v2.json
+# See https://docs.coderabbit.ai/reference/configuration for all fields and default values
+knowledge_base:
+  code_guidelines:
+    filePatterns:
+      - "docs/*-guidelines.md"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,80 @@
+# AGENTS.md
+
+This file provides orientation for AI agents and contributors working on **uhc-auth-proxy**. For project purpose and usage, see [README.md](README.md). For domain-specific rules, see the guideline files below.
+
+## Guideline Documents
+
+| File | Scope |
+|------|-------|
+| [docs/security-guidelines.md](docs/security-guidelines.md) | Token handling, user-agent validation, credential flow, and secrets management |
+| [docs/performance-guidelines.md](docs/performance-guidelines.md) | In-memory cache behavior, shared HTTP client, mutex patterns, and Prometheus metrics |
+| [docs/error-handling-guidelines.md](docs/error-handling-guidelines.md) | Custom error types (`HttpError`, `AccountError`), wrapping conventions, and status code propagation |
+| [docs/api-contracts-guidelines.md](docs/api-contracts-guidelines.md) | Endpoint contracts, accepted user-agents, and identity payload shape |
+| [docs/testing-guidelines.md](docs/testing-guidelines.md) | Ginkgo v2 / Gomega conventions, test wrappers, and cache clearing between tests |
+| [docs/integration-guidelines.md](docs/integration-guidelines.md) | External HTTP call patterns, UHC account management API interaction, and the `client.Wrapper` interface |
+
+## Repository Layout
+
+```
+main.go                     # Entrypoint -- delegates to cmd.Execute()
+cmd/
+  root.go                   # Cobra root command, Viper config init
+  start.go                  # `start` subcommand -- launches the HTTP server
+  run.go                    # `run` subcommand -- CLI one-shot identity fetch
+server/
+  server.go                 # chi router, middleware stack, RootHandler, Prometheus counters
+cache/
+  cache.go                  # In-memory TTL cache (2-hour expiry, mutex-guarded)
+requests/
+  client/
+    wrapper.go              # HTTPWrapper / Wrapper interface -- all outbound HTTP
+    access.go               # SSO token refresh with mutex-guarded caching
+    config.go               # Viper defaults for ACCESS_TOKEN_URL, TIMEOUT_SECONDS
+    types.go                # HttpError type
+  cluster/
+    cluster.go              # GetIdentity / GetCurrentAccount facade
+    types.go                # Registration, Account, Identity, test fakes
+    config.go               # Viper defaults for UHC API URLs
+logger/
+  logger.go                 # zap JSON logger with optional CloudWatch tee
+```
+
+## Cross-Cutting Conventions
+
+### Configuration
+
+All runtime configuration uses **Viper** with `AutomaticEnv()`. Defaults are set in package-level `init()` functions. There is no `.env` file; environment variables are the sole config source in deployed environments.
+
+### Naming
+
+- Package names are short, lowercase, singular (`cache`, `server`, `logger`).
+- JSON field names use `snake_case` to match the UHC API.
+- Prometheus metric names are prefixed `uhc_auth_proxy_`.
+
+### Interface-Based HTTP Abstraction
+
+The `client.Wrapper` interface is the seam for all outbound HTTP. Production code uses `HTTPWrapper`; tests use `FakeWrapper`, `ErrorWrapper`, or `ErrorWithBodyWrapper` (all defined in `requests/cluster/types.go`). Never call `http.DefaultClient` directly.
+
+### Logging
+
+Structured JSON logging via `zap`. Each package creates a named child logger (`log.Named("server")`). Always use `zap.Field` helpers (`zap.Error`, `zap.String`) rather than `fmt.Sprintf` in log calls.
+
+### Build and CI
+
+- **Dockerfile**: Multi-stage build using `ubi9/go-toolset` builder and `ubi9/ubi-minimal` runtime.
+- **Konflux/Tekton**: Pipelines in `.tekton/`. Unit tests run via `konflux_unit_test.sh` with `-race` and coverage.
+- **GitHub Actions**: `golangci-lint` on PRs. No Makefile — build with `go build`, test with `go test -v ./...`.
+
+## Architectural Notes
+
+- The service is stateless except for the in-memory cache. Restarting a pod clears all cached identities — this is intentional.
+- Data flow: `RootHandler` validates user-agent and bearer token → checks cache → calls UHC API on miss → caches and returns identity JSON.
+- Operator prefixes in `server.go` form an allowlist. Adding a new operator requires updating `operatorPrefixes` and the test's `validOperatorAgents` slice.
+
+## Common Pitfalls
+
+1. **Forgetting to clear cache in tests.** Every `BeforeEach` in server tests must call `cache.Clear()`.
+2. **Adding operators without updating tests.** The `operatorPrefixes` array and `validOperatorAgents` slice must stay in sync.
+3. **Nil-pointer in `wrapper.Do`.** `resp.StatusCode` is accessed before the `err != nil` check at line 61 — a nil `resp` will panic.
+4. **Viper `init()` ordering.** Multiple packages set defaults in `init()`. Always use environment variables for non-default values in tests.
+5. **JSON field mismatches.** The `Identity` struct uses `snake_case` JSON tags that downstream consumers depend on. Do not rename tags without coordinating with consumers.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,26 @@
+@AGENTS.md
+
+## Commands
+
+```bash
+# Build
+go build ./...
+
+# Test (matches CI)
+go test -v -race --coverprofile=coverage.txt --covermode=atomic ./...
+
+# Lint (matches GitHub Actions golangci-lint workflow)
+golangci-lint run
+```
+
+## CI Checks on PRs
+
+- **golangci-lint** runs on every PR via GitHub Actions. Fix all lint errors before pushing.
+- **Konflux/Tekton** builds a container image and runs `go test -v -race ./...` on every PR.
+- JSON/YAML files are validated automatically; malformed config files will fail CI.
+
+## Notes for Claude Code
+
+- There is no Makefile. Use `go build` and `go test` directly.
+- The `-race` flag is required in CI — run tests with it locally to catch data races before pushing.
+- Do not add a Makefile unless explicitly requested.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,96 @@
+# Contributing to uhc-auth-proxy
+
+## Start Here
+
+Read these docs before writing any code:
+
+- **[AGENTS.md](AGENTS.md)** — repo layout, conventions, architectural notes, and common pitfalls
+- **[CLAUDE.md](CLAUDE.md)** — build/test/lint commands and CI expectations
+- **[README.md](README.md)** — project purpose, data flow, and configuration
+
+The `docs/` guideline files cover security, performance, error handling, API contracts, testing, and integration patterns. Read the relevant ones before touching the corresponding code.
+
+---
+
+## 1. Local Development Setup
+
+```bash
+# Install the binary locally
+go install ./...
+
+# Build (verify compilation)
+go build ./...
+
+# Start the server on :8080
+uhc-auth-proxy start
+```
+
+No Makefile — use `go` commands directly. Do not add one.
+
+---
+
+## 2. Tests and Linting
+
+Run these before every push. They match CI exactly.
+
+```bash
+# Tests (race detector required — matches Konflux CI)
+go test -v -race --coverprofile=coverage.txt --covermode=atomic ./...
+
+# Lint (matches GitHub Actions golangci-lint workflow)
+golangci-lint run
+```
+
+Tests use Ginkgo v2 / Gomega. See [docs/testing-guidelines.md](docs/testing-guidelines.md) for conventions, including the requirement to call `cache.Clear()` in every `BeforeEach`.
+
+---
+
+## 3. Adding a New Operator Prefix
+
+This is the most common non-trivial contribution. Two files must change together — if they drift, tests will fail.
+
+**`server/server.go`**
+
+1. Add a named constant for the new prefix (follow the existing `const` block):
+   ```go
+   myNewOperatorPrefix = `my-new-operator/`
+   ```
+2. Add the constant to the `operatorPrefixes` array and update its size:
+   ```go
+   operatorPrefixes = [10]string{..., myNewOperatorPrefix}
+   ```
+
+**`server/server_test.go`**
+
+3. Add the operator name (without the trailing `/`) to `validOperatorAgents`:
+   ```go
+   validOperatorAgents := []string{..., "my-new-operator"}
+   ```
+
+Run `go test -v -race ./...` and confirm the new operator appears in passing test output.
+
+---
+
+## 4. PR Expectations
+
+**CI checks that must pass:**
+
+| Check | What it does |
+|-------|-------------|
+| `golangci-lint` (GitHub Actions) | Lint on every PR — fix all errors before pushing |
+| Konflux/Tekton unit tests | `go test -v -race ./...` in a container build |
+| JSON/YAML validation | Malformed config files fail automatically |
+
+**What reviewers look for:**
+
+- All outbound HTTP goes through `client.Wrapper`, never `http.DefaultClient`
+- New tests follow Ginkgo v2 / Gomega patterns and clear the cache in `BeforeEach`
+- Prometheus metric names stay prefixed `uhc_auth_proxy_`
+- JSON field tags on `Identity` and related structs use `snake_case` — do not rename without coordinating with consumers
+- No secrets or credentials in code or config files
+
+---
+
+## 5. Note for AI Agents
+
+Read [AGENTS.md](AGENTS.md) first — it is the authoritative orientation document. [CLAUDE.md](CLAUDE.md) has the exact commands for build, test, and lint. Do not create a Makefile. Run tests with `-race`.

--- a/README.md
+++ b/README.md
@@ -113,3 +113,54 @@ To run tests locally:
 ```
 $ go test -v ./...
 ```
+
+## Tech Stack
+
+| Concern | Library |
+|---------|---------|
+| HTTP router | [go-chi/chi v5](https://github.com/go-chi/chi) |
+| CLI framework | [spf13/cobra](https://github.com/spf13/cobra) |
+| Configuration | [spf13/viper](https://github.com/spf13/viper) |
+| Structured logging | [go.uber.org/zap](https://pkg.go.dev/go.uber.org/zap) |
+| Metrics | [prometheus/client_golang](https://github.com/prometheus/client_golang) |
+| Test framework | [onsi/ginkgo v2](https://onsi.github.io/ginkgo/) + [onsi/gomega](https://onsi.github.io/gomega/) |
+| RH platform middleware | [redhatinsights/platform-go-middlewares v2](https://github.com/RedHatInsights/platform-go-middlewares) |
+| CloudWatch logging | [RedHatInsights/cloudwatch-v2](https://github.com/RedHatInsights/cloudwatch-v2) |
+
+## Project Structure
+
+```
+main.go                     # Entrypoint — delegates to cmd.Execute()
+cmd/
+  root.go                   # Cobra root command, Viper config init
+  start.go                  # `start` subcommand — launches the HTTP server
+  run.go                    # `run` subcommand — CLI one-shot identity fetch
+server/
+  server.go                 # chi router, middleware stack, RootHandler, Prometheus counters
+cache/
+  cache.go                  # In-memory TTL cache (2-hour expiry, mutex-guarded)
+requests/
+  client/
+    wrapper.go              # HTTPWrapper / Wrapper interface — all outbound HTTP
+    access.go               # SSO token refresh with mutex-guarded caching
+    config.go               # Viper defaults for ACCESS_TOKEN_URL, TIMEOUT_SECONDS
+    types.go                # HttpError type
+  cluster/
+    cluster.go              # GetIdentity / GetCurrentAccount facade
+    types.go                # Registration, Account, Identity, test fakes
+    config.go               # Viper defaults for UHC API URLs
+logger/
+  logger.go                 # zap JSON logger with optional CloudWatch tee
+```
+
+## Documentation
+
+| Document | Description |
+|----------|-------------|
+| [AGENTS.md](AGENTS.md) | Orientation for AI agents and contributors: repo layout, cross-cutting conventions, architectural notes, and common pitfalls |
+| [docs/security-guidelines.md](docs/security-guidelines.md) | Token handling, user-agent validation, credential flow, and secrets management |
+| [docs/performance-guidelines.md](docs/performance-guidelines.md) | In-memory cache behavior, shared HTTP client, mutex patterns, and Prometheus metrics |
+| [docs/error-handling-guidelines.md](docs/error-handling-guidelines.md) | Custom error types, wrapping conventions, and HTTP status code propagation |
+| [docs/api-contracts-guidelines.md](docs/api-contracts-guidelines.md) | Endpoint contracts, accepted user-agents, and identity payload shape |
+| [docs/testing-guidelines.md](docs/testing-guidelines.md) | Ginkgo v2 / Gomega conventions, test wrappers, and cache clearing between tests |
+| [docs/integration-guidelines.md](docs/integration-guidelines.md) | External HTTP call patterns, UHC account management API interaction, and the `client.Wrapper` interface |

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,0 +1,49 @@
+# Architecture
+
+This document captures the reasoning behind uhc-auth-proxy's design decisions. For implementation details, see [AGENTS.md](../AGENTS.md). For domain-specific rules, see the guideline files in `docs/`.
+
+## Why This Service Exists
+
+OpenShift 4 clusters ship with an `insights-operator` that sends telemetry and diagnostic data to Red Hat. Authenticating these uploads requires associating each cluster with a Red Hat customer account. The naive solution would be to store SSO credentials on every cluster, but that creates a massive secret-management burden for customers and a large credential-sprawl attack surface.
+
+uhc-auth-proxy solves this by accepting the `cluster_id` and `authorization_token` that are already provisioned with every OpenShift 4 cluster, and translating them into an identity document that downstream platform services understand. This lets clusters authenticate with zero additional configuration by the customer.
+
+## The Two-Auth-Scheme Design
+
+Inbound requests carry a `Bearer <token>` header. Outbound requests to the UHC accounts management API use a different format: `AccessToken <cluster_id>:<token>`. The proxy does not pass the Bearer token through unchanged.
+
+This is intentional. The upstream UHC API requires the `AccessToken` scheme with the cluster ID and token combined. The Bearer scheme on the inbound side is a convention that lets the API gateway route the request to this proxy based on the User-Agent header without needing to understand the cluster-specific auth format. The proxy is the translation layer between these two auth worlds.
+
+## Why an Operator Allowlist
+
+The `operatorPrefixes` array in `server.go` restricts which User-Agent strings are accepted. Only known Red Hat operators (insights-operator, cost-mgmt-operator, etc.) can authenticate through this proxy.
+
+An open model was rejected because this proxy returns identity documents that grant access to customer account data in downstream services. Allowing arbitrary callers would turn any cluster credential into a general-purpose customer-account token. The allowlist ensures that only operators with a legitimate need to report data can use this path. Adding a new operator is intentionally a code change that requires review.
+
+## Why a 2-Hour Cache TTL
+
+The cache key is `clusterID:authorizationToken`, and entries expire after 2 hours. This TTL balances three concerns:
+
+1. **UHC API load**: Without caching, every request from every cluster hits the accounts management API. Operators report frequently (insights-operator reports every 2 hours by default), so caching for that interval eliminates nearly all redundant calls.
+2. **Token rotation correctness**: Because the authorization token is part of the cache key, a rotated token immediately bypasses the cache. The 2-hour window only applies to unchanged credentials.
+3. **Account change propagation**: If a customer's org ID or account number changes (rare), the stale cached identity persists for at most 2 hours. This was deemed acceptable since account metadata changes are infrequent and not time-critical for telemetry.
+
+## Why In-Memory Cache Instead of an External Store
+
+The service is intentionally stateless from a deployment perspective. A pod restart clears all cached identities, which is safe because the next request simply re-authenticates against the upstream API. An external cache would add operational complexity for a workload where cache misses are cheap and infrequent. Each pod in a scaled deployment maintains its own cache, but since operator requests are typically routed consistently, duplication is minimal.
+
+## The SSO Token (GetToken) Path
+
+`requests/client/access.go` contains a mutex-guarded SSO token cache that exchanges an offline access token (OAT) for a short-lived access token. This code exists but is not currently called in the production request path — the `AccessToken` scheme used by `wrapper.go` sends the cluster credentials directly without needing an SSO token. The SSO token path was part of an earlier auth flow and remains available as an alternative mechanism. The mutex serialization in `GetToken` would be a bottleneck under high concurrency if reactivated.
+
+## Why the Wrapper Interface
+
+All outbound HTTP goes through `client.Wrapper`, an interface with a single `Do` method. This exists purely as a test seam. The production implementation (`HTTPWrapper`) adds auth headers and makes real HTTP calls; test implementations (`FakeWrapper`, `ErrorWrapper`, `ErrorWithBodyWrapper`) return canned responses. This pattern was chosen over HTTP-level mocking because it keeps tests focused on the proxy's logic rather than HTTP plumbing.
+
+## Notable Tradeoffs and Known Issues
+
+- **No graceful shutdown**: The server runs `ListenAndServe` until the process is killed. In-flight requests are dropped. This is acceptable because the proxy is stateless and operator clients retry.
+- **No cache eviction**: Expired entries are only detected on read, never proactively evicted. Memory grows monotonically during a pod's lifetime, but is bounded by the cluster population.
+- **Nil-pointer bug in `wrapper.Do`**: `resp.StatusCode` is accessed before checking `err != nil`. If the HTTP call returns `(nil, error)`, the service panics. The `Recoverer` middleware prevents a crash but the request fails with a 500.
+- **Client timeout initialization order**: The `http.Client` timeout reads `TIMEOUT_SECONDS` via Viper at package init time, before Viper defaults are registered. If the env var is not set, the client has no timeout.
+- **Error message leaks auth header**: `getToken` in `server.go` includes the raw Authorization header in its error message when the format is invalid. This value is logged and returned to the caller.

--- a/docs/api-contracts-guidelines.md
+++ b/docs/api-contracts-guidelines.md
@@ -1,0 +1,157 @@
+# API Contracts Guidelines
+
+## Overview
+
+uhc-auth-proxy is an authentication proxy that validates OpenShift operator requests against Red Hat's account management service and returns an identity JSON payload. It has exactly two functional endpoints and a narrow set of accepted clients.
+
+## Routes
+
+| Method | Path | Handler | Purpose |
+|--------|------|---------|---------|
+| GET | `/` | `RootHandler` | Primary auth endpoint |
+| GET | `/api/uhc-auth-proxy/v1` | `RootHandler` | Versioned alias of `/` |
+| GET | `/status` | `StatusHandler` | Health/readiness check |
+| ANY | `/metrics` | `promhttp.Handler` | Prometheus metrics |
+
+The `/` and `/api/uhc-auth-proxy/v1` routes are registered with `r.Get` and share the same handler variable. The `/metrics` route is registered with `r.Handle`, which accepts all HTTP methods, though Prometheus scrapers always use GET. Any new auth behavior added to the shared handler automatically applies to both auth routes.
+
+## Request Contract
+
+### Required Headers
+
+Every request to the auth endpoint **must** include both headers. Missing or malformed values return `400`.
+
+#### User-Agent
+
+Format: `<operator-prefix><version> cluster/<cluster-id>`
+
+The operator prefix must be one of these exact strings (including the trailing slash):
+- `insights-operator/`
+- `cost-mgmt-operator/`
+- `marketplace-operator/`
+- `acm-operator/`
+- `assisted-installer-operator/`
+- `cryostat-operator/`
+- `openshift-lightspeed-operator/`
+- `jws-operator/`
+- `runtimes-inventory-operator/`
+
+The second space-delimited segment must begin with `cluster/`. The cluster ID is everything after that prefix.
+
+When adding a new operator, you must:
+1. Add a `const` with the prefix string in `server.go` and add it to the `operatorPrefixes` array (update the array size literal). Note: existing constants use a `*Prefix` naming convention (e.g., `insightsOperatorPrefix`), except `acmOperator` which does not follow this pattern.
+2. Add the operator name **without** the trailing slash (e.g., `"my-operator"`) to the `validOperatorAgents` slice in `server_test.go`.
+
+#### Authorization
+
+Format: `Bearer <token>`
+
+Must start with exactly `Bearer ` (capital B, single space). The token value after the prefix must be non-empty or the request will fail with 500 (empty token creates an incomplete Registration).
+
+### Request ID Propagation
+
+The proxy reads `x-rh-insights-request-id` from the incoming request and uses `request_id.ConfiguredRequestID` middleware to generate/propagate it. Both the original header value and the middleware-generated ID are logged on every request.
+
+## Response Contract
+
+### Success (200)
+
+Content-Type: `application/json`
+
+```json
+{
+  "account_number": "<ebs_account_id>",
+  "org_id": "<external_id>",
+  "type": "System",
+  "internal": {
+    "org_id": "<external_id>"
+  },
+  "system": {
+    "cluster_id": "<cluster_id>"
+  }
+}
+```
+
+Key facts:
+- `type` is always the literal string `"System"` — never vary this.
+- `account_number` comes from `organization.ebs_account_id` in the upstream account.
+- `org_id` (top-level) and `internal.org_id` both come from `organization.external_id`. Keep them in sync.
+- `system.cluster_id` is echoed from the request's User-Agent, not from the upstream service.
+- Successful responses are cached for 2 hours keyed on `<cluster_id>:<token>`. Cached responses are served as raw bytes, so they are byte-identical to the original.
+
+### Error Responses
+
+Errors are returned as **plain text** (not JSON). Only success responses set `Content-Type: application/json`.
+
+| Code | Condition | Body prefix |
+|------|-----------|-------------|
+| 400 | Invalid User-Agent | `Invalid user-agent:` |
+| 400 | Invalid Authorization header | `Invalid authorization header:` |
+| 500 | Empty token / incomplete Registration | `Could not form valid cluster registration object:` |
+| 401 | Upstream auth failure without an `HttpError` (default) | `Could not authenticate:` |
+| upstream code | Upstream returns an `HttpError` (any 4xx/5xx code) | `Could not authenticate:` |
+| 500 | JSON marshal failure | `Unable to read identity:` |
+
+Error status code logic (`getErrorStatusCode`):
+- If the error wraps a `client.HttpError`, use its `StatusCode` field directly, regardless of the value.
+- Otherwise, default to **401**.
+
+### Status Endpoint
+
+`GET /status` returns `{"status": "available"}` with no authentication required.
+
+## Middleware Stack
+
+Applied in this order via `chi.Use`:
+1. `request_id.ConfiguredRequestID("x-rh-insights-request-id")` — generates/propagates request IDs
+2. `middleware.RealIP` — trusts X-Forwarded-For / X-Real-IP
+3. `middleware.Logger` — request logging
+4. `middleware.Recoverer` — panic recovery returns 500
+5. `middleware.StripSlashes` — trailing slashes normalized
+
+Do not reorder these. The request-id middleware must be first.
+
+## Caching Behavior
+
+- Cache key: `<cluster_id>:<bearer_token>` (colon-separated)
+- TTL: 2 hours (hardcoded in `cache.Set`)
+- Cache stores raw JSON bytes, not deserialized structs
+- Cache is an in-memory `map[string]item` with a global mutex (no distributed cache)
+- On cache hit, the upstream account management service is **not** called
+- `cache.Clear()` is used in tests between scenarios; there is no runtime cache invalidation endpoint
+
+## Upstream Client Contract
+
+The `HTTPWrapper.Do` method adds headers for the upstream call to the account management service:
+
+```
+Authorization: AccessToken <cluster_id>:<authorization_token>
+Accept: application/json
+Content-Type: application/json
+```
+
+Note: the upstream `Authorization` format is `AccessToken`, not `Bearer`. This is a different scheme from what the proxy itself accepts.
+
+## Prometheus Metrics
+
+All Prometheus metrics use the `uhc_auth_proxy_` prefix:
+
+| Metric | Type | Labels |
+|--------|------|--------|
+| `uhc_auth_proxy_cache_hit` | Counter | none |
+| `uhc_auth_proxy_cache_miss` | Counter | none |
+| `uhc_auth_proxy_responses` | Counter | `code` |
+| `uhc_auth_proxy_request_time` | Histogram | `url` |
+| `uhc_auth_proxy_to_acct_mgmt_request_status` | Counter | `code` |
+
+When adding new metrics, follow this naming convention and always use `promauto.New*`.
+
+## Rules for Adding or Changing API Behavior
+
+1. **No request body parsing.** The proxy authenticates purely from headers.
+2. **Error responses are plain text.** Do not return JSON error bodies from the auth handler.
+3. **New operators require two code changes and one test change:** add a const and array entry (updating the array size literal) in `server.go`, and add the operator name (without trailing slash) to `validOperatorAgents` in `server_test.go`.
+4. **Status codes from upstream are forwarded.** Do not mask or remap upstream 4xx/5xx codes wrapped in `client.HttpError`.
+5. **Cache invalidation does not exist at runtime.** The 2-hour TTL is the only mechanism.
+6. **The `/` and `/api/uhc-auth-proxy/v1` routes share the same handler variable** and are therefore always in sync. Do not register separate handlers for these routes.
+7. **Content-Type is only set on success.** Error paths in the auth handler intentionally omit it.

--- a/docs/error-handling-guidelines.md
+++ b/docs/error-handling-guidelines.md
@@ -1,0 +1,126 @@
+# Error Handling Guidelines for uhc-auth-proxy
+
+## Custom Error Types
+
+### `client.HttpError`
+
+Defined in `requests/client/types.go`. Carries an HTTP `StatusCode` and `Message`. Created by `HTTPWrapper.Do` when the upstream response has status >= 400. The `StatusCode` field is the **only** mechanism for propagating upstream HTTP status codes back to the caller.
+
+### `cluster.AccountError`
+
+Defined in `requests/cluster/types.go`. Represents an error body returned by the OCM accounts API. Implements `zapcore.ObjectMarshaler` for structured logging via `zap.Object()`. Has an `Inner` field and implements `Unwrap() error` so it participates in the `errors.As`/`errors.Is` chain.
+
+## Error Wrapping Rules
+
+### Rule 1: Prefer `%w` when crossing package boundaries
+
+`cluster.GetIdentity` wraps errors from `GetCurrentAccount` using `fmt.Errorf("...: %w", err)`. This preserves the original error for type assertions upstream. Prefer `%w` (not `%v` or `%s`) when the caller needs to inspect the underlying error type.
+
+### Rule 2: AccountError wraps HttpError, not the other way around
+
+In `GetCurrentAccount`, when the wrapper returns both a body and an error, the body is unmarshalled into `AccountError` and the original error (typically `*client.HttpError`) is stored in `AccountError.Inner`. The chain is:
+
+```
+fmt.Errorf wrapping -> *AccountError -> (Inner) *client.HttpError
+```
+
+This means `errors.As(err, &accErr)` and `errors.As(err, &httpError)` can **both** succeed on the same error chain. The server relies on this.
+
+### Rule 3: Return body bytes alongside errors from Wrapper.Do
+
+`client.HTTPWrapper.Do` returns `(body, error)` where **both can be non-nil** when status >= 400. The body contains the upstream error response. Callers must check `b != nil` before attempting to unmarshal even when `err != nil`.
+
+## HTTP Status Code Propagation
+
+### Rule 4: Use `getErrorStatusCode` for mapping errors to response codes
+
+`server.getErrorStatusCode` uses `errors.As` to extract `*client.HttpError` from the error chain and returns its `StatusCode`. The **default** status code when no `HttpError` is found is **401** (not 500).
+
+### Rule 5: Input validation errors return 400, not 401
+
+Errors from `getClusterID` and `getToken` (malformed request headers) are handled **before** calling `GetIdentity` and return HTTP 400 directly.
+
+### Rule 6: Internal failures return 500
+
+`makeKey` failures (incomplete Registration) and `json.Marshal` failures return HTTP 500 directly, bypassing `getErrorStatusCode`.
+
+| Condition | Status Code |
+|---|---|
+| Invalid User-Agent | 400 |
+| Invalid Authorization header | 400 |
+| Incomplete Registration (empty token) | 500 |
+| Upstream auth failure with `HttpError` | Forward upstream code |
+| Upstream auth failure without `HttpError` | 401 |
+| JSON marshal failure | 500 |
+
+## Structured Logging with Zap
+
+### Rule 7: Prefer `zap.Error(err)` over `fmt.Sprintf` for error logging
+
+In most error paths in the server, `zap.Error(err)` is used as a structured field. Prefer this over `fmt.Sprintf` to inline errors into the message string. Note that `StatusHandler` currently uses `log.Error(fmt.Sprintf(...))` as an exception; new code in the request handler should use `zap.Error(err)` as the structured field instead.
+
+### Rule 8: Use `getErrorSpecificFields` to attach domain context
+
+When handling authentication failures, `getErrorSpecificFields` checks for `*cluster.AccountError` via `errors.As` and appends it as a `zap.Object` field. Extend this function when adding new error types that carry diagnostic data.
+
+### Rule 9: Include `cluster_id` in authentication error logs
+
+The server adds `zap.String("cluster_id", reg.ClusterID)` to the log fields for auth failures. Include it when logging errors related to a specific cluster.
+
+### Rule 10: Attach `request_id` via logger context, not per-call
+
+The server creates a per-request logger with `log.With(zap.String("request_id_header", reqID), ...)` and uses it for all subsequent log calls. Do not pass request ID as a separate field on each call.
+
+## Error Construction Patterns
+
+### Rule 11: Use `errors.New` for static sentinel errors
+
+Use `errors.New` for fixed error messages with no dynamic content (see `makeKey`). Use `fmt.Errorf` only when interpolating values into the message.
+
+### Rule 12: HttpError message should include URL, status code, and status text
+
+Follow the pattern in `HTTPWrapper.Do`:
+
+```go
+fmt.Sprintf("request to %s failed: %d %s", req.URL.String(), resp.StatusCode, resp.Status)
+```
+
+## Testing Error Handling
+
+### Rule 13: Use test wrapper types for error simulation
+
+| Type | Behavior |
+|---|---|
+| `FakeWrapper` | Returns a configured successful response |
+| `ErrorWrapper` | Always returns an error with nil body |
+| `ErrorWithBodyWrapper` | Returns both a JSON body and a `*client.HttpError` |
+
+### Rule 14: Verify error type with `errors.Unwrap` in tests
+
+When testing error wrapping, unwrap to the expected depth and assert with `BeAssignableToTypeOf`. The cluster test package uses a dot-import of `requests/cluster`, so `AccountError` can be referenced unqualified:
+
+```go
+unwrap := errors.Unwrap(err)
+Expect(unwrap).To(BeAssignableToTypeOf(&AccountError{}))
+```
+
+### Rule 15: Clear the cache in BeforeEach for error tests
+
+`cache.Clear()` must be called in `BeforeEach` blocks for server handler tests. Cached successful responses mask error paths and cause false passes.
+
+### Rule 16: Assert HTTP status codes on the ResponseRecorder
+
+Server tests use `rr.Result().StatusCode` to verify the HTTP status code returned for each error scenario. Every new error path in the handler must have a corresponding status code assertion.
+
+## Response Body on Errors
+
+Write a human-readable message to the response body via `fmt.Fprintf`. The `AccountError.Error()` method formats as `[Reason: ..., Code: ..., ID: ...]` which propagates upstream diagnostic info to the caller. Do not return empty bodies on error.
+
+## Wrapper Interface Contract
+
+The `client.Wrapper` interface returns `([]byte, error)`:
+- `(body, nil)` — success
+- `(body, err)` — upstream error with response body (may contain structured error JSON)
+- `(nil, err)` — transport or other failure with no body
+
+When implementing a new `Wrapper`, return `*HttpError` for HTTP failures so the status code propagates. Return the body alongside the error when available.

--- a/docs/integration-guidelines.md
+++ b/docs/integration-guidelines.md
@@ -1,0 +1,134 @@
+# Integration Guidelines
+
+Rules and patterns for making external HTTP calls in uhc-auth-proxy.
+
+## Architecture Overview
+
+All outbound HTTP calls go through a single path:
+
+1. `requests/client/wrapper.go` — shared HTTP client, auth headers, metrics, error handling
+2. `requests/cluster/cluster.go` — account management service facade
+3. `server/server.go` — maps upstream errors to HTTP responses, caches identity results
+
+## External Endpoints
+
+All external URLs are configured via environment variables with defaults set in `init()` functions:
+
+| Variable | Default | Package |
+|---|---|---|
+| `CURRENT_ACCOUNT_URL` | `https://api.openshift.com/api/accounts_mgmt/v1/current_account` | `cluster` |
+| `GET_ACCOUNTID_URL` | `https://api.openshift.com/api/accounts_mgmt/v1/cluster_registrations` | `cluster` |
+| `ACCOUNT_DETAILS_URL` | `https://api.openshift.com/api/accounts_mgmt/v1/accounts/%s` | `cluster` |
+| `ORG_DETAILS_URL` | `https://api.openshift.com/api/accounts_mgmt/v1/organizations/%s` | `cluster` |
+| `ACCESS_TOKEN_URL` | `https://sso.redhat.com/auth/realms/redhat-external/protocol/openid-connect/token` | `client` |
+| `TIMEOUT_SECONDS` | (none — must be set via env var) | `client` |
+
+Use `viper.GetString()` to read endpoint URLs at call time rather than storing them at init time. This allows tests and deployments to override values after init. Note that `TIMEOUT_SECONDS` is read once at package load time (in the `var` block of `wrapper.go`, before viper defaults apply) and cannot be changed at runtime.
+
+## The Wrapper Pattern
+
+All outbound HTTP calls to the account management API go through the `client.Wrapper` interface:
+
+```go
+type Wrapper interface {
+    Do(req *http.Request, label string, cluster_id string, authorization_token string) ([]byte, error)
+}
+```
+
+Rules:
+1. Never call `http.Client.Do()` directly from business logic. Always go through a `Wrapper`.
+2. The `label` parameter is used for Prometheus metrics, not routing. Pass the URL string (e.g., the value returned by `viper.GetString("CURRENT_ACCOUNT_URL")`), not the variable name.
+3. `Do()` adds Authorization, Accept, and Content-Type headers automatically. Do not set these on the request before calling `Do()`.
+4. The Authorization header uses the format `AccessToken {cluster_id}:{authorization_token}`. This is not a Bearer token — it is specific to the accounts management API.
+
+## HTTP Client Configuration
+
+A single package-level `http.Client` is shared across all requests in `requests/client/wrapper.go`.
+
+Rules:
+1. Do not create additional `http.Client` instances. Use the shared client.
+2. The timeout is set at package load time from `TIMEOUT_SECONDS`. There is no retry logic anywhere in the codebase. If a request fails, it fails.
+3. There is no custom Transport, connection pooling config, or TLS settings — the Go defaults apply.
+
+## Error Handling
+
+### Two-tier error model
+
+`wrapper.Do()` returns `([]byte, error)` where both can be non-nil simultaneously:
+- **Status >= 400**: Returns the response body AND a `*client.HttpError` with `StatusCode` and `Message`.
+- **Transport error**: Returns `nil` body and the underlying error.
+
+Rules:
+1. When `wrapper.Do()` returns an error, always check whether the body (`[]byte`) is also non-nil. A non-nil body on error means the upstream returned a structured error response.
+2. Use `errors.As(err, &httpError)` to extract the status code from `*client.HttpError`.
+3. Default to HTTP 401 when the error is not an `HttpError`.
+
+### AccountError (structured upstream errors)
+
+When `GetCurrentAccount` receives both a body and an error, it attempts to unmarshal the body into `*cluster.AccountError`:
+
+```go
+if b != nil {
+    res := &AccountError{}
+    if json.Unmarshal(b, res) == nil {
+        res.Inner = err
+        return nil, res
+    }
+}
+```
+
+Rules:
+1. `AccountError` wraps the original `HttpError` via its `Inner` field and implements `Unwrap()`. Use `errors.As` to reach either layer.
+2. When logging an `AccountError`, use `zap.Object("account_error_verbose", accErr)` — it implements `zapcore.ObjectMarshaler`.
+3. Any new external call that returns structured error JSON should follow this same pattern.
+
+## Known Bug: Nil dereference in wrapper.Do
+
+There is a latent nil-pointer risk in `wrapper.go`: `resp.StatusCode` is accessed before the `err != nil` check. If the HTTP call fails with a transport error (DNS failure, timeout), `resp` will be nil and this line will panic. Any fix must move the metric increment to after the nil check.
+
+## Caching
+
+- Successful identity lookups are cached for 2 hours in `cache/cache.go`. Cache key is `{cluster_id}:{authorization_token}`.
+- Cache is checked before calling `GetIdentity`. If the cache returns non-nil, no external call is made.
+- Only cache successful results. Errors are never cached.
+- Call `cache.Clear()` at the start of every test that exercises the handler.
+
+## SSO Token Management
+
+`requests/client/access.go` manages OAuth tokens for the SSO endpoint:
+1. Tokens are cached in a package-level variable with a mutex.
+2. A token is refreshed when expired (`now >= expires`) or when the cached token string is empty.
+3. This is a `refresh_token` grant type flow against Red Hat SSO.
+
+## Testing Patterns
+
+### Use the in-repo fakes, not mocks
+
+| Fake | Purpose |
+|---|---|
+| `FakeWrapper` | Returns a preconfigured `*Account` response |
+| `ErrorWrapper` | Always returns an error with nil body |
+| `ErrorWithBodyWrapper` | Returns both a JSON body and a `*client.HttpError` |
+
+When testing error paths that involve structured error bodies, use `ErrorWithBodyWrapper` and set both `AccountError` and `StatusCode`.
+
+### Always clear cache between tests
+
+Call `cache.Clear()` in `BeforeEach` blocks. The global in-memory cache persists across test cases.
+
+### Test error unwrapping explicitly
+
+Verify error chain with `errors.As` or `errors.Unwrap`, not string matching:
+
+```go
+unwrap := errors.Unwrap(err)
+Expect(unwrap).To(BeAssignableToTypeOf(&AccountError{}))
+```
+
+### Valid user-agent format in handler tests
+
+Requests must have a user-agent matching `{operator-prefix}/{version} cluster/{cluster_id}`. The recognized operator prefixes are defined in `server/server.go`.
+
+## Prometheus Metrics
+
+Any new external call must record request duration and status code using the existing `promauto` registration pattern. Use the `uhc_auth_proxy_` prefix for all metric names.

--- a/docs/performance-guidelines.md
+++ b/docs/performance-guidelines.md
@@ -1,0 +1,97 @@
+# Performance Guidelines
+
+## Architecture Overview
+
+uhc-auth-proxy is a single-binary HTTP proxy that authenticates OpenShift cluster requests against UHC account management APIs. It uses an in-memory cache, a shared HTTP client, and mutex-protected critical sections. There are no goroutines launched by application code; all concurrency comes from `net/http` serving requests on separate goroutines.
+
+## Critical Sections and Lock Ordering
+
+### 1. Cache lock (`cache/cache.go`)
+
+The cache uses a package-level `sync.Mutex` protecting a `map[string]item`. The lock is held only for the map read or write operation, never across I/O.
+
+Rules:
+- Never hold the cache mutex while performing network calls or any blocking I/O.
+- Always lock/unlock around a single map operation (get or set), never across compound operations.
+- Do not add a `sync.RWMutex` without profiling first; the current lock hold time is sub-microsecond and contention is unlikely to be a bottleneck relative to the upstream HTTP call.
+- Expired entries are detected on read but never evicted. If adding eviction, use a separate goroutine with its own timer rather than scanning under the write lock.
+
+### 2. Token lock (`requests/client/access.go`)
+
+`GetToken` uses a `sync.Mutex` with `defer mutex.Unlock()` and holds the lock across a network call (`fetch`) when the token is expired. This function exists in the codebase but is not currently called from the production request path.
+
+Rules:
+- If `GetToken` is wired into the request flow, be aware it is a serialization point: when the token expires, all concurrent requests block behind a single `fetch` call. Do not make this worse by adding work inside the critical section.
+- If you need to reduce contention, use a `singleflight.Group` keyed on the offline access token instead of a bare mutex.
+- Never cache the token outside this mutex. The single-writer pattern here prevents token races.
+
+### 3. Lock ordering
+
+The cache package has one active mutex. `requests/client/access.go` defines a second mutex not currently invoked in the production request path. **Do not introduce a call path that acquires both locks** (e.g., calling `cache.Set` while holding the token mutex). If you must, always acquire the token lock first, then the cache lock.
+
+## HTTP Client
+
+### Shared client (`requests/client/wrapper.go`)
+
+A single `http.Client` is initialized as a package-level variable in `wrapper.go` using `viper.GetDuration("TIMEOUT_SECONDS") * time.Second` for the timeout. Because this variable is initialized before `config.go`'s `init()` runs, the `viper.SetDefault("TIMEOUT_SECONDS", 30)` default has not yet been registered at that point. In practice, the client timeout is controlled entirely by the `TIMEOUT_SECONDS` environment variable, which must be set before the process starts. If the environment variable is absent, the client has no timeout. Both account management calls in `wrapper.go` and SSO token-fetch calls in `access.go` use this shared client.
+
+Rules:
+- Do not create per-request `http.Client` instances. The shared client reuses connections via the default `http.Transport` connection pool.
+- The `TIMEOUT_SECONDS` value is read once at package variable initialization time. Changing the env var at runtime has no effect. If dynamic timeout configuration is needed, set the timeout on the `http.Request` context instead.
+- The default `http.Transport` has `MaxIdleConns: 100` and `MaxIdleConnsPerHost: 2`. Since this service talks to a small number of upstream hosts, consider setting `MaxIdleConnsPerHost` to a higher value (e.g., 10-20) on a custom transport if connection reuse becomes a bottleneck.
+- `io.ReadAll` is used to consume response bodies in both `wrapper.go` and `access.go`. For this service the payloads are small JSON (< 10 KB). Do not switch to streaming unless payload sizes grow significantly.
+
+### Bug: nil-pointer dereference in `Do`
+
+In `wrapper.go`, `resp.StatusCode` is accessed before the `err != nil` check. If `client.Do` returns `(nil, err)`, this panics. Any fix must preserve the Prometheus counter increment for all responses but move it after the nil check.
+
+## Cache Behavior
+
+Rules:
+- Cache TTL is hardcoded to 2 hours (`cache.go`). Do not change this without understanding the downstream impact: a shorter TTL increases load on UHC account management APIs; a longer TTL delays propagation of account changes.
+- Cache keys are `clusterID:authorizationToken` (`server.go` `makeKey`). This means a token rotation immediately bypasses the cache, which is correct behavior.
+- The cache grows unboundedly. In practice this is acceptable because the number of distinct cluster+token pairs is finite and entries are small (`[]byte` of marshaled `Identity` JSON). If the service starts handling significantly more clusters, add an LRU eviction policy or bounded map.
+- Always call `cache.Clear()` in test `BeforeEach` blocks to prevent cross-test cache pollution.
+
+## Prometheus Metrics
+
+| Metric | Type | Location | Labels |
+|--------|------|----------|--------|
+| `uhc_auth_proxy_request_time` | Histogram | `wrapper.go` | `url` |
+| `uhc_auth_proxy_to_acct_mgmt_request_status` | Counter | `wrapper.go` | `code` |
+| `uhc_auth_proxy_cache_hit` | Counter | `server.go` | none |
+| `uhc_auth_proxy_cache_miss` | Counter | `server.go` | none |
+| `uhc_auth_proxy_responses` | Counter | `server.go` | `code` |
+
+Rules:
+- Use `promauto` for registration (existing convention). Never call `prometheus.MustRegister` directly.
+- The `url` label on `request_time` uses the full URL string. This is safe only because the service calls a fixed set of upstream URLs. Do not add metrics with unbounded label cardinality (e.g., cluster IDs, request IDs).
+- Histogram buckets are tuned for sub-second to 5-second responses. If upstream latency characteristics change, adjust the buckets to avoid most observations falling into a single bucket.
+
+## Server Configuration
+
+| Env Var | Default | Effect |
+|---------|---------|--------|
+| `SERVER_PORT` | `8080` | Listen port |
+| `TIMEOUT_SECONDS` | (none — must be set via env var) | HTTP client timeout (read at package init, before viper defaults apply) |
+| `ACCESS_TOKEN_URL` | `https://sso.redhat.com/...` | SSO token endpoint |
+| `CURRENT_ACCOUNT_URL` | `https://api.openshift.com/...` | Account lookup endpoint |
+| `CLIENT_ID` | (none) | OAuth client ID |
+
+Rules:
+- The server does not configure `ReadTimeout`, `WriteTimeout`, or `IdleTimeout` on `http.Server`. If adding these, set `WriteTimeout` greater than `TIMEOUT_SECONDS` to avoid killing requests waiting for a slow upstream response.
+- No graceful shutdown is implemented. `ListenAndServe` runs until process termination. If adding graceful shutdown, drain the cache and flush CloudWatch logs before exiting.
+
+## Middleware Stack
+
+The chi router uses these middlewares in order: `request_id`, `RealIP`, `Logger`, `Recoverer`, `StripSlashes`.
+
+Rules:
+- `Recoverer` catches panics per-request. Do not remove it.
+- `Logger` runs on every request including `/metrics` and `/status`. If log volume becomes a problem, add a path-based filter to skip health check endpoints.
+
+## What NOT to Optimize
+
+- **String splitting in `getClusterID`**: Runs once per request on a short string. The linear scan over 9 operator prefixes is negligible.
+- **JSON marshal/unmarshal of Identity**: Payloads are tiny. Do not introduce code generation or pooling for this.
+- **Package-level init functions**: The viper defaults and logger initialization run once at startup. They are not hot paths.

--- a/docs/security-guidelines.md
+++ b/docs/security-guidelines.md
@@ -1,0 +1,116 @@
+# Security Guidelines for uhc-auth-proxy
+
+## Purpose
+
+This proxy authenticates OpenShift cluster operators (insights-operator, cost-mgmt-operator, etc.) by validating their `cluster_id` and `authorization_token` against the UHC accounts management API. These guidelines codify the security conventions in the codebase so that contributors and AI agents produce consistent, secure changes.
+
+## Architecture Security Model
+
+The proxy sits between cluster operators and the Red Hat accounts management API. It receives a Bearer token and cluster ID from operator User-Agent headers, forwards them as an `AccessToken` credential to the upstream API, and returns an identity JSON used by downstream services. The proxy itself holds an offline access token (`OAT`) used to obtain short-lived access tokens from SSO.
+
+**Trust boundary:** The proxy trusts nothing from the inbound HTTP request. Every request must pass User-Agent validation and Bearer token extraction before any upstream call is made.
+
+## 1. User-Agent Allowlist
+
+Only requests from recognized operator prefixes are accepted. The allowlist is defined in `server/server.go` as `operatorPrefixes`.
+
+Rules:
+- Do not remove the `strings.HasPrefix` check or the `cluster/` prefix requirement in `getClusterID`.
+- When adding a new operator, add its prefix to the `operatorPrefixes` array and add a corresponding test case in the `validOperatorAgents` slice in `server/server_test.go`.
+- The User-Agent must match the format `<operator-prefix><version> cluster/<cluster_id>`. Requests that do not match get a 400 response.
+- Do not fall back to a default cluster ID if parsing fails.
+
+## 2. Bearer Token Handling
+
+Rules:
+- The `getToken` function in `server/server.go` requires the exact prefix `Bearer ` (with trailing space). Do not accept `Bearer:` or other variants.
+- The `getToken` error message currently includes the raw authorization header value in the error string (`"not a bearer token: '%s'"`), and this error is logged via `zap.Error`. Avoid extending this pattern — do not log successfully extracted token values. If modifying `getToken`, consider redacting the header value in the error message.
+- The `makeKey` function rejects registrations where either `ClusterID` or `AuthorizationToken` is empty, returning a 500. Do not weaken this check.
+
+## 3. Cache Key Construction
+
+The in-memory cache in `cache/cache.go` uses `clusterID:authorizationToken` as the key.
+
+Rules:
+- The cache key must always include both the cluster ID and the full authorization token. This ensures that a stolen or rotated token cannot retrieve a cached identity from a previous token.
+- Cache entries expire after 2 hours (hardcoded in `cache.Set`). Do not increase this TTL without security review.
+- Always call `cache.Clear()` in test `BeforeEach` blocks to prevent cross-test cache pollution.
+
+## 4. Upstream Credential Forwarding
+
+The `HTTPWrapper.AddHeaders` method in `requests/client/wrapper.go` constructs the upstream authorization header:
+
+```go
+req.Header.Add("Authorization", fmt.Sprintf("AccessToken %s:%s", cluster_id, authorization_token))
+```
+
+Rules:
+- Do not change this format without coordinating with the upstream accounts management API team.
+- Do not add the raw `Bearer` token from the inbound request to outbound requests — only use the `AccessToken` format.
+- The HTTP client has a configurable timeout (`TIMEOUT_SECONDS`). Do not set this to zero or remove the timeout.
+
+## 5. SSO Token Management
+
+The `requests/client/access.go` file manages the proxy's own SSO access token using the `OAT` (offline access token) environment variable.
+
+Rules:
+- The offline access token is fetched from the `OAT` env var, sourced from a Kubernetes secret (`uhc-auth-proxy-secret`). Never hardcode this value.
+- The `CLIENT_ID` is sourced from a secret and used in the SSO token request. `CLIENT_SECRET` is defined in the Kubernetes template but is not currently referenced in the Go code. Do not add defaults for these in config files.
+- Token refresh uses a mutex-protected package-level variable with expiry. Do not remove the `mutex.Lock()`/`defer mutex.Unlock()` pattern — it prevents concurrent token refresh races.
+- The `ACCESS_TOKEN_URL` default points to `sso.redhat.com`. Do not change this default to a non-HTTPS URL.
+
+## 6. Error Handling and Information Disclosure
+
+Rules:
+- Error responses to clients should not leak internal URLs, stack traces, or upstream response bodies. The current pattern wraps errors with user-facing messages like `"Could not authenticate"`. Note that `getToken` currently includes the raw authorization header in its error message — exercise caution when modifying error messages to avoid expanding information disclosure.
+- When the upstream API returns an error body, it is parsed into `AccountError` and logged server-side with `zap.Object` for structured diagnostics. The client receives only the reason, code, and ID fields via `AccountError.Error()` — do not add raw upstream response bodies to client-facing output.
+- Use `errors.As` for error type switching (see `getErrorStatusCode`). Do not use type assertions directly.
+- Default to HTTP 401 when the upstream error type is unknown. Do not default to 200 or 500 for authentication failures.
+
+## 7. Secret and Configuration Management
+
+All secrets are injected via environment variables sourced from Kubernetes secrets (see `openshift/uhc-auth-proxy-template.yaml`).
+
+Rules:
+- Sensitive env vars: `OAT`, `CLIENT_ID`, `CLIENT_SECRET`, `CW_AWS_ACCESS_KEY_ID`, `CW_AWS_SECRET_ACCESS_KEY`. Never log these values.
+- Do not add `viper.SetDefault` for any secret value. Defaults are only acceptable for non-sensitive configuration like `SERVER_PORT`, `TIMEOUT_SECONDS`, `LOG_LEVEL`, CloudWatch log group/region/stream, and upstream API URLs.
+- The `.gitignore` and `.dockerignore` should not be modified to include secret files.
+
+## 8. HTTP Server Configuration
+
+Rules:
+- The server uses `chi` middleware: `request_id.ConfiguredRequestID`, `RealIP`, `Logger`, `Recoverer`, and `StripSlashes`. Do not remove `Recoverer` — it prevents panics from crashing the process and leaking stack traces.
+- The `/metrics` endpoint exposes Prometheus metrics. It does not require authentication (it is accessed by internal scrapers), but it should not expose secret values in metric labels.
+- The `/status` endpoint is used for liveness/readiness probes. It must remain unauthenticated and lightweight.
+- The server binds to a configurable port (default 8080). It does not configure TLS directly — TLS termination is handled by the OpenShift router/ingress.
+
+## 9. Logging Security
+
+Rules:
+- All logging uses structured JSON via `zap`. Do not use `fmt.Println` for operational logging (it is acceptable in CLI `cmd/` code).
+- Do not add `zap.String("token", ...)` or log any field containing a Bearer token, OAT, or AWS secret key. Note that `getToken` currently includes the raw authorization header in its error string when the format is invalid — avoid extending this pattern to valid tokens.
+- The `cluster_id` is safe to log and is already included in error logs. The `authorization_token` is not — maintain this distinction.
+- CloudWatch integration uses static AWS credentials. If modifying `logger/cloudwatch.go`, ensure credentials are only read from `logConfig` (which sources from env vars), not from config files on disk.
+
+## 10. Testing Security Patterns
+
+Rules:
+- Use `FakeWrapper`, `ErrorWrapper`, and `ErrorWithBodyWrapper` (defined in `requests/cluster/types.go`) for test mocking. Do not make real HTTP calls to upstream APIs in unit tests.
+- Test both valid and invalid inputs for all parsing functions (`getClusterID`, `getToken`, `makeKey`). The existing test suite covers empty auth, malformed User-Agent, and missing cluster prefixes.
+- When adding a new operator to the allowlist, add a test in `server/server_test.go` that exercises the full handler path (via the `call` helper function), not just the `getClusterID` parser.
+- Use `httptest.NewRecorder` for handler tests. Do not start a real HTTP server in unit tests.
+
+## 11. Dockerfile Security
+
+Rules:
+- The final image uses `ubi9/ubi-minimal`, not a full OS image. Do not switch to a larger base without justification.
+- The binary is built with `CGO_ENABLED=0` for a static binary. Do not enable CGO unless absolutely necessary.
+- CVE patches for base image packages are applied via `microdnf update` for specific packages. When adding CVE fixes, target only the affected packages rather than running a blanket `microdnf update`.
+- The build stage runs as `root` for dependency fetching and compilation. The final stage does not set a USER directive — consider adding `USER 1001` if the deployment does not already enforce a non-root security context.
+
+## 12. Dependency Management
+
+Rules:
+- Dependencies are managed via `go.mod`. Review any new dependency for security implications before adding it.
+- Automated dependency update PRs (from Mintmaker/Konflux) should be reviewed for breaking changes in security-sensitive packages (`net/http`, TLS libraries, authentication libraries).
+- The `go.sum` file must always be committed alongside `go.mod` changes to ensure integrity verification.

--- a/docs/testing-guidelines.md
+++ b/docs/testing-guidelines.md
@@ -1,0 +1,155 @@
+# Testing Guidelines for uhc-auth-proxy
+
+## Framework and Setup
+
+All tests use **Ginkgo v2** with **Gomega** matchers. Do not use standard `testing.T` assertions or `testify`. Run tests with:
+
+```bash
+go test -v -race --coverprofile=coverage.txt --covermode=atomic ./...
+```
+
+## Suite File Convention
+
+Every package with tests has a `*_suite_test.go` bootstrap file. When adding tests to a new package, create this file first:
+
+```go
+package mypkg_test
+
+import (
+    "testing"
+    . "github.com/onsi/ginkgo/v2"
+    . "github.com/onsi/gomega"
+)
+
+func TestMyPkg(t *testing.T) {
+    RegisterFailHandler(Fail)
+    RunSpecs(t, "MyPkg Suite")
+}
+```
+
+## Package Access Conventions
+
+Two patterns coexist — follow the one already used in the package you are modifying:
+
+- **External test package** (`package foo_test`): Used in `cache` and `requests/cluster` packages. Import the package under test with dot-import.
+- **Internal test package** (`package foo`): Used in `server` and `logger` packages. The `server` test is internal to access unexported functions like `getClusterID`, `getToken`, and `makeKey`. The `logger` test is internal to stub the unexported `getCloudwatchCore` function variable.
+
+Do not switch a package from internal to external or vice versa.
+
+## Dot-Imports
+
+Ginkgo and Gomega are always dot-imported. The package under test is dot-imported only in external test packages. No other packages should be dot-imported.
+
+## Describe/It Structure
+
+Tests use a two-level nesting pattern. Prefer not to nest `Describe` blocks more than two levels deep. A common naming convention is `"When <condition>"` for Describe blocks and `"should <expected behavior>"` for It blocks, though existing tests do not apply this uniformly — follow the convention already used in the file you are modifying:
+
+```go
+Describe("When passed a valid user-agent header", func() {
+    It("should return a cluster id", func() {
+        // ...
+    })
+})
+```
+
+## BeforeEach for Test Isolation
+
+Use `BeforeEach` to reset shared state before each `It` block:
+
+1. **Cache state**: Call `cache.Clear()` in `BeforeEach` when testing handlers or any code that touches the cache.
+2. **Wrapper and account setup**: Initialize `FakeWrapper`, `ErrorWrapper`, and `ErrorWithBodyWrapper` structs in `BeforeEach`, not at the `Describe` level. Fields on these structs (such as `AccountError` or `StatusCode` on `ErrorWithBodyWrapper`) may be set per `It` block when different tests require different values.
+
+```go
+BeforeEach(func() {
+    account = &cluster.Account{
+        Organization: cluster.Org{EbsAccountID: "123", ExternalID: "123"},
+    }
+    wrapper = &cluster.FakeWrapper{GetAccountResponse: account}
+    cache.Clear()
+})
+```
+
+## Mocking External HTTP Calls via Wrapper Interface
+
+The codebase does **not** use `httptest.Server` to mock upstream API calls. Instead, it uses the `client.Wrapper` interface with fake implementations in `requests/cluster/types.go`:
+
+| Wrapper | Purpose | Behavior |
+|---|---|---|
+| `FakeWrapper` | Happy path | Returns a marshaled `Account` based on `GetAccountResponse` |
+| `ErrorWrapper` | Error without body | Returns `nil` bytes and a generic error |
+| `ErrorWithBodyWrapper` | Error with OCM-style body | Returns marshaled `AccountError` bytes and a `client.HttpError` with configurable `StatusCode` |
+
+When adding new error scenarios, extend or create a new wrapper in `requests/cluster/types.go` — do not create wrapper mocks inside test files.
+
+## Testing HTTP Handlers
+
+Handler tests use `httptest.NewRecorder` (not `httptest.NewServer`). The `server` package has a shared `call` helper function:
+
+```go
+func call(wrapper client.Wrapper, userAgent string, auth string) (*httptest.ResponseRecorder, *cluster.Identity)
+```
+
+Rules for handler tests:
+- Prefer using `call()` rather than creating your own request/recorder setup.
+- The returned `Identity` will be zero-value (`&cluster.Identity{}`) on error paths.
+- Check `rr.Result().StatusCode` for HTTP status assertions.
+- Check `rr.Body` with `io.ReadAll` and `ContainSubstring` for error body content.
+
+## Testing Error Propagation
+
+When testing error paths with `ErrorWithBodyWrapper`, set both `StatusCode` and `AccountError` fields before calling. Verify error chain behavior with `errors.Unwrap`:
+
+```go
+unwrap := errors.Unwrap(err)
+Expect(unwrap).To(BeAssignableToTypeOf(&AccountError{}))
+```
+
+## Table-Driven Tests
+
+For testing multiple valid inputs against the same assertion, use a loop over a slice inside a single `Describe` block:
+
+```go
+validOperatorAgents := []string{"insights-operator", "cost-mgmt-operator", ...}
+for _, a := range validOperatorAgents {
+    It(fmt.Sprintf("should return a valid Identity json for %s", a), func() {
+        _, ident := call(wrapper, fmt.Sprintf("%s/abc cluster/123", a), "Bearer mytoken")
+        Expect(ident.AccountNumber).To(Equal("123"))
+    })
+}
+```
+
+## Logger Tests and Environment Stubbing
+
+Logger tests use `github.com/prashantv/gostub` to stub environment variables and function variables. Reset stubs with `defer stubs.Reset()` and reset global logger state in `AfterEach`:
+
+```go
+AfterEach(func() {
+    resetLogger()
+})
+```
+
+## Assertion Conventions
+
+- Use `Expect(err).To(BeNil())` for nil error checks.
+- Use `Expect(err).To(Not(BeNil()))` for non-nil error checks.
+- Use `Equal()` for exact value matching.
+- Use `ContainSubstring()` for partial string matching on response bodies.
+- Use `BeAssignableToTypeOf()` for type assertions on error types.
+
+## What Must Be Tested
+
+When modifying code, ensure tests cover:
+
+1. **Valid input happy path** — correct return values and types.
+2. **Invalid input** — proper error returns and HTTP status codes.
+3. **Empty/missing input** — edge cases like empty tokens or missing headers.
+4. **Error propagation** — errors from wrappers surface correctly, including status codes from upstream services.
+5. **Cache interaction** — behavior is correct with both empty and populated caches.
+
+## Adding a New Operator Prefix
+
+When adding a new operator to `operatorPrefixes` in `server/server.go`:
+1. Add the prefix constant.
+2. Add it to the `operatorPrefixes` array (update the array size literal).
+3. Add the operator name (without trailing slash) to the `validOperatorAgents` slice in `server/server_test.go`.
+4. The existing table-driven loop will automatically generate a test case.


### PR DESCRIPTION
- Add 6 domain-specific guideline files (docs/*-guidelines.md) covering security, performance, error handling, API contracts, testing, and integration patterns with repo-specific conventions
- Add AGENTS.md as the primary onboarding doc for AI agents and contributors
- Add CLAUDE.md as a thin Claude Code-specific layer importing AGENTS.md
- Add CONTRIBUTING.md with local dev setup and operator prefix guide
- Add docs/ARCHITECTURE.md capturing design decisions and known issues
- Add .coderabbit.yaml pointing CodeRabbit to the guideline files
- Update README.md with Tech Stack table, Project Structure tree, and docs index

Created using the `/agent-readiness` skill from https://github.com/gwenneg/claude-engineering-toolkit

https://redhat.atlassian.net/browse/RHCLOUD-46906