### PR TITLE
chore: update UBI9 base images

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@
 ############################
 # STEP 1 build executable binary
 ############################
-FROM registry.access.redhat.com/ubi9/go-toolset:9.8-1779959429 AS builder
+FROM registry.access.redhat.com/ubi9/go-toolset:9.8-1781070142 AS builder
 
 LABEL name="uhc-auth-proxy" \
       summary="UHC Auth Proxy - OpenShift Cluster Authentication Service" \

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/redhatinsights/uhc-auth-proxy
 
-go 1.26.3
+go 1.26.2
 
 require (
 	github.com/RedHatInsights/cloudwatch-v2 v0.0.0-20260421143546-03c50d49af21

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/redhatinsights/uhc-auth-proxy
 
-go 1.26.2
+go 1.26.3
 
 require (
 	github.com/RedHatInsights/cloudwatch-v2 v0.0.0-20260421143546-03c50d49af21


### PR DESCRIPTION
## Summary

Update UBI9 container base images to latest available versions from Red Hat Container Catalog.

## Changes

| Dockerfile | Image | Old Tag | New Tag | Health |
|------------|-------|---------|---------|--------|
| `Dockerfile` | `ubi9/go-toolset` | `9.8-1779959429` | `9.8-1781070142` | A |

## Motivation

- Keep base images current with security patches
- Maintain compliance with container health requirements
- Reduce technical debt from outdated base images

## Verification

- [ ] Container builds succeed locally
- [ ] CI/CD pipeline passes
- [ ] Application functions correctly with updated base

## References

- [Red Hat Container Catalog](https://catalog.redhat.com/software/containers/)
- Latest tags verified via Pyxis API

## Test Plan

1. Verify container builds complete successfully
2. Run application smoke tests
3. Confirm no regression in functionality

🤖 Generated with [Claude Code](https://claude.ai/code)
