### PR TITLE
RHCLOUD-48899 - Update to use hummingbird as new base image

### DIFF
--- a/.tekton/uhc-auth-proxy-pull-request.yaml
+++ b/.tekton/uhc-auth-proxy-pull-request.yaml
@@ -216,7 +216,7 @@ spec:
             # set the working directory to value from previous step
           workingDir: /var/workdir/source
             # Use image that suites your use case
-          image: registry.access.redhat.com/ubi9/go-toolset:9.8-1782377916
+          image: registry.access.redhat.com/hi/go:1.26.4-fips-builder
           securityContext:
               # If the task step needs write access to the volume, set the runAsUser to 0 (root).
             runAsUser: 0

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -61,7 +61,7 @@ Structured JSON logging via `zap`. Each package creates a named child logger (`l
 
 ### Build and CI
 
-- **Dockerfile**: Multi-stage build using `ubi9/go-toolset` builder and `ubi9/ubi-minimal` runtime.
+- **Dockerfile**: Multi-stage build using Hummingbird FIPS images (`hi/go:1.26.4-fips-builder` and `hi/core-runtime:2.42-openssl-fips`). FIPS mode is enabled via `GODEBUG=fips140=on`.
 - **Konflux/Tekton**: Pipelines in `.tekton/`. Unit tests run via `konflux_unit_test.sh` with `-race` and coverage.
 - **GitHub Actions**: `golangci-lint` on PRs. No Makefile — build with `go build`, test with `go test -v ./...`.
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@
 ############################
 # STEP 1 build executable binary
 ############################
-FROM registry.access.redhat.com/ubi9/go-toolset:9.8-1782377916 AS builder
+FROM registry.access.redhat.com/hi/go:1.26.4-fips-builder AS builder
 
 LABEL name="uhc-auth-proxy" \
       summary="UHC Auth Proxy - OpenShift Cluster Authentication Service" \
@@ -24,13 +24,6 @@ COPY . .
 # Using go get requires root.
 USER root
 
-# TODO: Remove once base image includes Go 1.26.4
-ENV GO_VERSION=1.26.4
-RUN curl -fsSL "https://go.dev/dl/go${GO_VERSION}.linux-amd64.tar.gz" -o /tmp/go.tar.gz && \
-    rm -rf /usr/local/go && \
-    tar -C /usr/local -xzf /tmp/go.tar.gz && \
-    rm /tmp/go.tar.gz
-
 ENV PATH="/usr/local/go/bin:${PATH}"
 
 RUN go get -d -v
@@ -39,11 +32,12 @@ RUN CGO_ENABLED=0 go build -o /go/bin/uhc-auth-proxy
 ############################
 # STEP 2 build a small image
 ############################
-FROM registry.access.redhat.com/ubi9/ubi-minimal:9.8-1782797275
+FROM registry.access.redhat.com/hi/core-runtime:2.42-openssl-fips
 
 # Copy our static executable.
 COPY --from=builder /go/bin/uhc-auth-proxy /go/bin/uhc-auth-proxy
 # Default port
 # EXPOSE 8080/tcp
 # Run the hello binary.
+ENV GODEBUG=fips140=on
 ENTRYPOINT ["/go/bin/uhc-auth-proxy", "start"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -24,8 +24,6 @@ COPY . .
 # Using go get requires root.
 USER root
 
-ENV PATH="/usr/local/go/bin:${PATH}"
-
 RUN go get -d -v
 # Build the binary.
 RUN CGO_ENABLED=0 go build -o /go/bin/uhc-auth-proxy

--- a/docs/security-guidelines.md
+++ b/docs/security-guidelines.md
@@ -103,9 +103,9 @@ Rules:
 ## 11. Dockerfile Security
 
 Rules:
-- The final image uses `ubi9/ubi-minimal`, not a full OS image. Do not switch to a larger base without justification.
+- The build uses Hummingbird FIPS-compliant images: `hi/go:1.26.4-fips-builder` for building and `hi/core-runtime:2.42-openssl-fips` for runtime. Do not switch to non-FIPS images without security approval.
+- FIPS 140 mode is enabled via `GODEBUG=fips140=on`. This environment variable must remain set in the final image.
 - The binary is built with `CGO_ENABLED=0` for a static binary. Do not enable CGO unless absolutely necessary.
-- CVE patches for base image packages are applied via `microdnf update` for specific packages. When adding CVE fixes, target only the affected packages rather than running a blanket `microdnf update`.
 - The build stage runs as `root` for dependency fetching and compilation. The final stage does not set a USER directive — consider adding `USER 1001` if the deployment does not already enforce a non-root security context.
 
 ## 12. Dependency Management


### PR DESCRIPTION
https://redhat.atlassian.net/browse/RHCLOUD-48899

Run command to build docker image:

`docker build -t test_humming .`